### PR TITLE
about ParamPattern and java.util.Date

### DIFF
--- a/pippo-controller/pom.xml
+++ b/pippo-controller/pom.xml
@@ -20,6 +20,14 @@
             <artifactId>pippo-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 </project>

--- a/pippo-controller/src/main/java/ro/pippo/controller/DefaultControllerHandler.java
+++ b/pippo-controller/src/main/java/ro/pippo/controller/DefaultControllerHandler.java
@@ -18,6 +18,7 @@ package ro.pippo.controller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.Param;
+import ro.pippo.core.ParamPattern;
 import ro.pippo.core.ParameterValue;
 import ro.pippo.core.PippoRuntimeException;
 import ro.pippo.core.route.RouteContext;
@@ -172,6 +173,7 @@ public class DefaultControllerHandler implements ControllerHandler {
     @SuppressWarnings("unchecked")
     protected Object[] prepareMethodArgs(RouteContext routeContext) {
         Class<?>[] types = method.getParameterTypes();
+        Parameter[] parameters = method.getParameters();
 
         if (types.length == 0) {
             return new Object[]{};
@@ -199,7 +201,12 @@ public class DefaultControllerHandler implements ControllerHandler {
                         args[i] = value.toCollection((Class<? extends Collection>) type, genericType, null);
                     }
                 } else {
-                    args[i] = value.to(type);
+                    ParamPattern pattern = parameters[i].getAnnotation(ParamPattern.class);
+                    if (pattern != null) {
+                        args[i] = value.to(type, pattern.value());
+                    } else {
+                        args[i] = value.to(type);
+                    }
                 }
             }
         }

--- a/pippo-controller/src/test/java/ControllerHandlerTest.java
+++ b/pippo-controller/src/test/java/ControllerHandlerTest.java
@@ -19,26 +19,33 @@ import ro.pippo.controller.DefaultControllerHandler;
 import ro.pippo.core.Param;
 import ro.pippo.core.ParamPattern;
 
+import static org.junit.Assert.assertNotNull;
+
 /**
  * @author ScienJus
- * @date 2016/3/2.
  */
 public class ControllerHandlerTest {
 
     @Test
-    public void testFindMethodWithDate() throws Exception {
-        DefaultControllerHandler handler = new DefaultControllerHandler(DateController.class, "testDate");
-        handler = new DefaultControllerHandler(DateController.class, "testDateWithPattern");
+    public void testDateParam() throws Exception {
+        DefaultControllerHandler handler = new DefaultControllerHandler(DateController.class, "testDateParam");
+        assertNotNull(handler.getMethod());
+    }
+
+    @Test
+    public void testDateParamWithPattern() throws Exception {
+        DefaultControllerHandler handler = new DefaultControllerHandler(DateController.class, "testDateParamWithPattern");
+        assertNotNull(handler.getMethod());
     }
 
     static class DateController extends Controller {
 
-        public void testDate(@Param("date") java.util.Date since) {
+        public void testDateParam(@Param("date") java.util.Date since) {
             System.out.println(since);
         }
 
         // yyyy-MM-dd HH:mm is not supported from in java.sql.Date/Time/Timestamp, just for test
-        public void testDateWithPattern(@ParamPattern("yyyy-MM-dd HH:mm") @Param("date") java.util.Date since) {
+        public void testDateParamWithPattern(@ParamPattern("yyyy-MM-dd HH:mm") @Param("date") java.util.Date since) {
             System.out.println(since);
         }
 

--- a/pippo-controller/src/test/java/ControllerHandlerTest.java
+++ b/pippo-controller/src/test/java/ControllerHandlerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.junit.Test;
+import ro.pippo.controller.Controller;
+import ro.pippo.controller.DefaultControllerHandler;
+import ro.pippo.core.Param;
+import ro.pippo.core.ParamPattern;
+
+/**
+ * @author ScienJus
+ * @date 2016/3/2.
+ */
+public class ControllerHandlerTest {
+
+    @Test
+    public void testFindMethodWithDate() throws Exception {
+        DefaultControllerHandler handler = new DefaultControllerHandler(DateController.class, "testDate");
+        handler = new DefaultControllerHandler(DateController.class, "testDateWithPattern");
+    }
+
+    static class DateController extends Controller {
+
+        public void testDate(@Param("date") java.util.Date since) {
+            System.out.println(since);
+        }
+
+        // yyyy-MM-dd HH:mm is not supported from in java.sql.Date/Time/Timestamp, just for test
+        public void testDateWithPattern(@ParamPattern("yyyy-MM-dd HH:mm") @Param("date") java.util.Date since) {
+            System.out.println(since);
+        }
+
+    }
+}

--- a/pippo-core/src/main/java/ro/pippo/core/ParameterValue.java
+++ b/pippo-core/src/main/java/ro/pippo/core/ParameterValue.java
@@ -318,6 +318,17 @@ public class ParameterValue implements Serializable {
         }
     }
 
+    private Date toDateFromUnixTimestamp() {
+        if (isNull() || StringUtils.isNullOrEmpty(values[0])) {
+            return null;
+        }
+        try {
+            return new Date(Long.parseLong(values[0]));
+        } catch (NumberFormatException e) {
+            throw new PippoRuntimeException(e);
+        }
+    }
+
     public java.sql.Date toSqlDate() {
         return toSqlDate(null);
     }
@@ -515,6 +526,11 @@ public class ParameterValue implements Serializable {
 
             if (type == Timestamp.class) {
                 return toSqlTimestamp();
+            }
+            // support java.util.Date
+            if (Date.class.isAssignableFrom(type)) {
+                //default from unix timestamp like System.currentTimeMillis()
+                return toDateFromUnixTimestamp();
             }
         } else {
             if (Date.class.isAssignableFrom(type)) {


### PR DESCRIPTION
from https://github.com/decebals/pippo/issues/256

When pippo start, `DefaultControllerHandler.findMethod`will create some `ParameterValue` and call them `to` method, is there a better ways like call a method named `isSupport`? whatever, when method has a `java.util.Date` parameter, there will a error beacause `ParameterValue.to` is not support `java.util.Date` without `pattern`, and `DefaultControllerHandler.findMethod` do not parse `@ParamPatter`。

So I did these things:
1. when method has a `java.util.Date` parameter and without `@ParamPattern`, it will be converted  from a unix timestamp like `System.currentTimeMillis()`, because it's useful and not be supported by `@ParamPattern`.
2. in `DefaultControllerHandler.findMethod`, find all `@ParamPattern.value` from method parameters. and sent to `ParameterValue.to`

I could not find a good way to test it in unit test, but i create a real web application and it worked fine.
