### PR TITLE
Add support for Prometheus (metrics)

### DIFF
--- a/pippo-metrics-parent/pippo-metrics-prometheus/README.md
+++ b/pippo-metrics-parent/pippo-metrics-prometheus/README.md
@@ -1,0 +1,1 @@
+Please see [Prometheus](http://www.pippo.ro/mod/metrics/prometheus.html) page from the documentation site.

--- a/pippo-metrics-parent/pippo-metrics-prometheus/pom.xml
+++ b/pippo-metrics-parent/pippo-metrics-prometheus/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>ro.pippo</groupId>
+        <artifactId>pippo-metrics-parent</artifactId>
+        <version>1.10.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <artifactId>pippo-metrics-prometheus</artifactId>
+    <version>1.10.0-SNAPSHOT</version>
+    <name>Pippo Metrics Prometheus</name>
+    <description>Prometheus Metrics integration</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>ro.pippo</groupId>
+            <artifactId>pippo-metrics</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.dhatim</groupId>
+            <artifactId>dropwizard-prometheus</artifactId>
+            <version>2.1.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pippo-metrics-parent/pippo-metrics-prometheus/src/main/java/ro/pippo/prometheus/Reporter.java
+++ b/pippo-metrics-parent/pippo-metrics-prometheus/src/main/java/ro/pippo/prometheus/Reporter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.prometheus;
+
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import org.dhatim.dropwizard.prometheus.PrometheusReporter;
+import org.dhatim.dropwizard.prometheus.Pushgateway;
+import org.kohsuke.MetaInfServices;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ro.pippo.core.PippoSettings;
+import ro.pippo.metrics.MetricsReporter;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Integration of Pippo Metrics with <a href="https://prometheus.io">Prometheus</a>.
+ *
+ * @author Decebal Suiu
+ */
+@MetaInfServices
+public class Reporter implements MetricsReporter {
+
+    private final Logger log = LoggerFactory.getLogger(Reporter.class);
+
+    private PrometheusReporter reporter;
+
+    @Override
+    public void start(PippoSettings settings, MetricRegistry metricRegistry) {
+        if (settings.getBoolean("metrics.prometheus.enabled", false)) {
+            String hostname = settings.getLocalHostname();
+            String address = settings.getRequiredString("metrics.prometheus.address");
+            int port = settings.getInteger("metrics.prometheus.port", 2003);
+            long period = settings.getDurationInSeconds("metrics.prometheus.period", 60);
+
+            Pushgateway pushgateway = new Pushgateway(address, port);
+            reporter = PrometheusReporter.forRegistry(metricRegistry)
+                .prefixedWith(hostname)
+                .filter(MetricFilter.ALL)
+                .build(pushgateway);
+            reporter.start(period, TimeUnit.SECONDS);
+
+            log.info("Started Prometheus Metrics reporter for '{}', updating every {} seconds", hostname, period);
+        } else {
+            log.debug("Prometheus Metrics reporter is disabled");
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (reporter != null) {
+            reporter.stop();
+            log.debug("Stopped Prometheus Metrics reporter");
+        }
+    }
+
+}

--- a/pippo-metrics-parent/pom.xml
+++ b/pippo-metrics-parent/pom.xml
@@ -6,19 +6,20 @@
         <artifactId>pippo-parent</artifactId>
         <version>1.10.0-SNAPSHOT</version>
     </parent>
-    
+
     <groupId>ro.pippo</groupId>
     <artifactId>pippo-metrics-parent</artifactId>
     <version>1.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    
+
     <name>Pippo Metrics Parent</name>
-    
+
     <modules>
         <module>pippo-metrics</module>
         <module>pippo-metrics-ganglia</module>
         <module>pippo-metrics-graphite</module>
         <module>pippo-metrics-influxdb</module>
         <module>pippo-metrics-librato</module>
+        <module>pippo-metrics-prometheus</module>
     </modules>
 </project>


### PR DESCRIPTION
This PR comes to solve #415.

Add the following dependency to your application pom.xml:
```xml
<dependency>
    <groupId>ro.pippo</groupId>
    <artifactId>pippo-metrics-prometheus</artifactId>
    <version>${pippo.version}</version>
</dependency>
```

Add the following settings to your application.properties:
```properties
metrics.prometheus.enabled = true
metrics.prometheus.address = prometheus.example.com // default 'localhost'
metrics.prometheus.port = 9091
metrics.prometheus.period = 60 seconds
```