### PR TITLE
FileItem's inputstream is closed properly now

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/FileItem.java
+++ b/pippo-core/src/main/java/ro/pippo/core/FileItem.java
@@ -117,13 +117,8 @@ public class FileItem {
      * @throws IOException
      */
     public void write(File file) throws IOException {
-        InputStream inputStream = null;
-        try {
-            inputStream = getInputStream();
+        try (InputStream inputStream = getInputStream()) {
             IoUtils.copy(inputStream, file);
-        } finally {
-            if (inputStream != null)
-                inputStream.close();
         }
     }
 

--- a/pippo-core/src/main/java/ro/pippo/core/FileItem.java
+++ b/pippo-core/src/main/java/ro/pippo/core/FileItem.java
@@ -117,7 +117,14 @@ public class FileItem {
      * @throws IOException
      */
     public void write(File file) throws IOException {
-        IoUtils.copy(getInputStream(), file);
+        InputStream inputStream = null;
+        try {
+            inputStream = getInputStream();
+            IoUtils.copy(inputStream, file);
+        } finally {
+            if (inputStream != null)
+                inputStream.close();
+        }
     }
 
     /**


### PR DESCRIPTION
write method of file item doesn't closed newly created `inputStream` post usage
this fix closes it in a finally block