### PR TITLE
Add Handlers class as a factory for common RouteHandler

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/route/Handlers.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/Handlers.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core.route;
+
+import ro.pippo.core.RedirectHandler;
+import ro.pippo.core.TemplateHandler;
+
+/**
+ * Factory for common {@link RouteHandler}s.
+ *
+ * @author Decebal Suiu
+ */
+public class Handlers {
+
+    public static RouteHandler newCSRFHandler() {
+        return new CSRFHandler();
+    }
+
+    public static RouteHandler newPublicResourceHandler() {
+        return new PublicResourceHandler();
+    }
+
+    public static RouteHandler newWebjarsResourceHandler() {
+        return new WebjarsResourceHandler();
+    }
+
+    public static RouteHandler newRedirectHandler(String path) {
+        return new RedirectHandler(path);
+    }
+
+    public static RouteHandler newTemplateHandler(String template) {
+        return new TemplateHandler(template);
+    }
+
+    public static RouteHandler newTrailingSlashHandler(boolean addSlash) {
+        return new TrailingSlashHandler(addSlash);
+    }
+
+}


### PR DESCRIPTION
The idea is that sometime I want to have a place with all common route handlers (defined in core). 
It's something similar with Executors from Java.
The implementation based on factory pattern.

What you say, it's useful or not?