### PR TITLE
Call SharedMetricRegistries.setDefault in MetricsInitializer

### DIFF
--- a/pippo-metrics-parent/pippo-metrics/src/main/java/ro/pippo/metrics/CountedHandler.java
+++ b/pippo-metrics-parent/pippo-metrics/src/main/java/ro/pippo/metrics/CountedHandler.java
@@ -17,6 +17,8 @@ package ro.pippo.metrics;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
+import ro.pippo.core.Application;
 import ro.pippo.core.route.RouteContext;
 import ro.pippo.core.route.RouteHandler;
 
@@ -31,6 +33,14 @@ public class CountedHandler implements RouteHandler {
     final boolean isActive;
     final MetricRegistry metricRegistry;
     final RouteHandler routeHandler;
+
+    /**
+     * This constructor uses {@link SharedMetricRegistries#getDefault()} as metric registry.
+     * The default (global) metric registry is set in {@link MetricsInitializer#init(Application)}.
+     */
+    public CountedHandler(String counterName, boolean isActive, RouteHandler routeHandler) {
+        this(counterName, isActive, SharedMetricRegistries.getDefault(), routeHandler);
+    }
 
     public CountedHandler(String counterName, boolean isActive, MetricRegistry metricRegistry, RouteHandler routeHandler) {
         this.counterName = counterName;

--- a/pippo-metrics-parent/pippo-metrics/src/main/java/ro/pippo/metrics/MeteredHandler.java
+++ b/pippo-metrics-parent/pippo-metrics/src/main/java/ro/pippo/metrics/MeteredHandler.java
@@ -17,6 +17,8 @@ package ro.pippo.metrics;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
+import ro.pippo.core.Application;
 import ro.pippo.core.route.RouteContext;
 import ro.pippo.core.route.RouteHandler;
 
@@ -30,6 +32,14 @@ public class MeteredHandler implements RouteHandler {
     final String meterName;
     final MetricRegistry metricRegistry;
     final RouteHandler routeHandler;
+
+    /**
+     * This constructor uses {@link SharedMetricRegistries#getDefault()} as metric registry.
+     * The default (global) metric registry is set in {@link MetricsInitializer#init(Application)}.
+     */
+    public MeteredHandler(String meterName, RouteHandler routeHandler) {
+        this(meterName, SharedMetricRegistries.getDefault(), routeHandler);
+    }
 
     public MeteredHandler(String meterName, MetricRegistry metricRegistry, RouteHandler routeHandler) {
         this.meterName = meterName;

--- a/pippo-metrics-parent/pippo-metrics/src/main/java/ro/pippo/metrics/MetricsInitializer.java
+++ b/pippo-metrics-parent/pippo-metrics/src/main/java/ro/pippo/metrics/MetricsInitializer.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.metrics;
 
+import com.codahale.metrics.SharedMetricRegistries;
 import com.codahale.metrics.jmx.JmxReporter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
@@ -60,6 +61,9 @@ public class MetricsInitializer implements Initializer {
             metricRegistry = new MetricRegistry();
 //            application.getLocals().put("metricRegistry", metricRegistry);
         }
+
+        // set created metricRegistry as default
+        SharedMetricRegistries.setDefault("pippo", metricRegistry);
 
         // init reporters
         reporters = new ArrayList<>();

--- a/pippo-metrics-parent/pippo-metrics/src/main/java/ro/pippo/metrics/MetricsTransformer.java
+++ b/pippo-metrics-parent/pippo-metrics/src/main/java/ro/pippo/metrics/MetricsTransformer.java
@@ -52,35 +52,21 @@ public class MetricsTransformer implements RouteTransformer {
             }
         }
 
-        String metricName = route.getName();
-        if (StringUtils.isNullOrEmpty(metricName)) {
-            metricName = MetricRegistry.name(method.getDeclaringClass(), method.getName());
-        }
-
         RouteHandler handler = null;
         if (method.isAnnotationPresent(Metered.class)) {
             log.debug("Found '{}' annotation on method '{}'", Metered.class.getSimpleName(), LangUtils.toString(method));
-            // route handler is Metered
             Metered metered = method.getAnnotation(Metered.class);
-            if (!metered.value().isEmpty()) {
-                metricName = metered.value();
-            }
+            String metricName = !metered.value().isEmpty() ? metered.value() : getMetricName(route, method);
             handler = new MeteredHandler(metricName, metricRegistry, route.getRouteHandler());
         } else if (method.isAnnotationPresent(Timed.class)) {
             log.debug("Found '{}' annotation on method '{}'", Timed.class.getSimpleName(), LangUtils.toString(method));
-            // route handler is Timed
             Timed timed = method.getAnnotation(Timed.class);
-            if (!timed.value().isEmpty()) {
-                metricName = timed.value();
-            }
+            String metricName = !timed.value().isEmpty() ? timed.value() : getMetricName(route, method);
             handler = new TimedHandler(metricName, metricRegistry, route.getRouteHandler());
         } else if (method.isAnnotationPresent(Counted.class)) {
             log.debug("Found '{}' annotation on method '{}'", Counted.class.getSimpleName(), LangUtils.toString(method));
-            // route handler is Counted
             Counted counted = method.getAnnotation(Counted.class);
-            if (!counted.value().isEmpty()) {
-                metricName = counted.value();
-            }
+            String metricName = !counted.value().isEmpty() ? counted.value() : getMetricName(route, method);
             handler = new CountedHandler(metricName, counted.active(), metricRegistry, route.getRouteHandler());
         }
 
@@ -89,6 +75,15 @@ public class MetricsTransformer implements RouteTransformer {
         }
 
         return route;
+    }
+
+    private String getMetricName(Route route, Method method) {
+        String metricName = route.getName();
+        if (StringUtils.isNullOrEmpty(metricName)) {
+            metricName = MetricRegistry.name(method.getDeclaringClass(), method.getName());
+        }
+
+        return metricName;
     }
 
 }

--- a/pippo-metrics-parent/pippo-metrics/src/main/java/ro/pippo/metrics/MetricsTransformer.java
+++ b/pippo-metrics-parent/pippo-metrics/src/main/java/ro/pippo/metrics/MetricsTransformer.java
@@ -24,6 +24,7 @@ import ro.pippo.core.route.RouteContext;
 import ro.pippo.core.route.RouteHandler;
 import ro.pippo.core.route.RouteTransformer;
 import ro.pippo.core.util.LangUtils;
+import ro.pippo.core.util.StringUtils;
 
 import java.lang.reflect.Method;
 
@@ -51,7 +52,10 @@ public class MetricsTransformer implements RouteTransformer {
             }
         }
 
-        String metricName = MetricRegistry.name(method.getDeclaringClass(), method.getName());
+        String metricName = route.getName();
+        if (StringUtils.isNullOrEmpty(metricName)) {
+            metricName = MetricRegistry.name(method.getDeclaringClass(), method.getName());
+        }
 
         RouteHandler handler = null;
         if (method.isAnnotationPresent(Metered.class)) {

--- a/pippo-metrics-parent/pippo-metrics/src/main/java/ro/pippo/metrics/TimedHandler.java
+++ b/pippo-metrics-parent/pippo-metrics/src/main/java/ro/pippo/metrics/TimedHandler.java
@@ -16,7 +16,9 @@
 package ro.pippo.metrics;
 
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
 import com.codahale.metrics.Timer;
+import ro.pippo.core.Application;
 import ro.pippo.core.route.RouteContext;
 import ro.pippo.core.route.RouteHandler;
 
@@ -30,6 +32,14 @@ public class TimedHandler implements RouteHandler {
     final String timerName;
     final MetricRegistry metricRegistry;
     final RouteHandler routeHandler;
+
+    /**
+     * This constructor uses {@link SharedMetricRegistries#getDefault()} as metric registry.
+     * The default (global) metric registry is set in {@link MetricsInitializer#init(Application)}.
+     */
+    public TimedHandler(String timerName, RouteHandler routeHandler) {
+        this(timerName, SharedMetricRegistries.getDefault(), routeHandler);
+    }
 
     public TimedHandler(String timerName, MetricRegistry metricRegistry, RouteHandler routeHandler) {
         this.timerName = timerName;


### PR DESCRIPTION
Before this PR we register a meter metric for a route (handler) with `@Metered` annotation
```java
// send a template as response
GET("/template", new RouteHandler() {

    @Metered
    public void handle(RouteContext routeContext) {
        routeContext.render("hello"); // render "hello" template
    }

});
```

The inconvenient here is that I am forced to create an anonymous class and that the meter name is compose from the class name (useless in this case) and the method name ("handle"). So, the meter name is useless.

This approach with `@Metered` annotation on `handle` method is useful when we have concrete route handler
```java
public class MyHandler implements RouteHandler {

    @Metered
    public void handle(RouteContext routeContext) {
        routeContext.render("hello"); // render "hello" template
    }

}
```
In this case, the meter name is "MyHandler.handle".

This PR comes to resolve this problem, so you can write something like
```java
// metered route
GET("/metered", new MeteredHandler("testMetered", routeContext -> routeContext.send("Metered !!!")));
```

**Above sentences about metric name are valid if you don't supply implicit the metric name in annotation (with `@Metered("testMetered")` - the same for `@Counted` and `@Timed`).**

Of course, for `Controller`s the things are very clear and this PR change nothing.

If you see other modality, more elegant, to add a metric to a route, please let me know.