### PR TITLE
Closing the writer will close the stream as well. Fix for #455.

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/gzip/GZipResponseWrapper.java
+++ b/pippo-core/src/main/java/ro/pippo/core/gzip/GZipResponseWrapper.java
@@ -81,7 +81,6 @@ public class GZipResponseWrapper extends HttpServletResponseWrapper {
 
     public void finish() {
         IoUtils.close(writer);
-        IoUtils.close(stream);
     }
 
     private ServletOutputStream createOutputStream() throws IOException {


### PR DESCRIPTION
Calling close twice on the stream will throw an exception ( which is silently ignored ). 
I don't think this change has any effect. It is just annoying if you debug your application and set the debugger to halt on every exception and see it halting within Pippo. 