### PR TITLE
Update Tomcat to 8.5.34

### DIFF
--- a/pippo-server-parent/pippo-tomcat/pom.xml
+++ b/pippo-server-parent/pippo-tomcat/pom.xml
@@ -14,7 +14,7 @@
     <description>Tomcat Embedded Web Server</description>
 
     <properties>
-        <tomcat.version>8.0.33</tomcat.version>
+        <tomcat.version>8.5.34</tomcat.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Tomcat 8.0.33 is an obsolete version used right now having vulnerabilities.
 Updating to Tomcat 8.5.34