### PR TITLE
feat: add wrapper method to get header names

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/Request.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Request.java
@@ -434,6 +434,14 @@ public final class Request {
         return httpServletRequest.getHeaders(name);
     }
 
+    /**
+     * Wrapper function to get all request header names
+     * @return the enumerator for request headers
+     */
+    public Enumeration<String> getHeaderNames() {
+        return httpServletRequest.getHeaderNames();
+    }
+
     public boolean isSecure() {
         return httpServletRequest.isSecure();
     }


### PR DESCRIPTION
Without this `gethttpRequestServletRequest().getHeaderNames()`, should be used.