### PR TITLE
feat(gzip): send gzip response when Accept-Encoding:* is present

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/gzip/GZipFilter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/gzip/GZipFilter.java
@@ -65,7 +65,7 @@ public class GZipFilter implements Filter {
         String acceptEncoding = request.getHeader("accept-encoding");
 
         return !StringUtils.isNullOrEmpty(acceptEncoding) && (
-            acceptEncoding.contains("gzip")  || acceptEncoding.contains("*")
+            acceptEncoding.contains("gzip") || acceptEncoding.contains("*")
         );
     }
 

--- a/pippo-core/src/main/java/ro/pippo/core/gzip/GZipFilter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/gzip/GZipFilter.java
@@ -15,6 +15,8 @@
  */
 package ro.pippo.core.gzip;
 
+import ro.pippo.core.util.StringUtils;
+
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -62,7 +64,9 @@ public class GZipFilter implements Filter {
     protected boolean acceptsGZipEncoding(HttpServletRequest request) {
         String acceptEncoding = request.getHeader("accept-encoding");
 
-        return acceptEncoding != null && acceptEncoding.contains("gzip");
+        return !StringUtils.isNullOrEmpty(acceptEncoding) && (
+            acceptEncoding.contains("gzip")  || acceptEncoding.contains("*")
+        );
     }
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/gzip/GZipRequestResponseFactory.java
+++ b/pippo-core/src/main/java/ro/pippo/core/gzip/GZipRequestResponseFactory.java
@@ -55,7 +55,7 @@ public class GZipRequestResponseFactory extends RequestResponseFactory {
         String acceptEncoding = httpServletRequest.getHeader("accept-encoding");
 
         return !StringUtils.isNullOrEmpty(acceptEncoding) && (
-            acceptEncoding.contains("gzip")  || acceptEncoding.contains("*")
+            acceptEncoding.contains("gzip") || acceptEncoding.contains("*")
         );
     }
 

--- a/pippo-core/src/main/java/ro/pippo/core/gzip/GZipRequestResponseFactory.java
+++ b/pippo-core/src/main/java/ro/pippo/core/gzip/GZipRequestResponseFactory.java
@@ -20,6 +20,7 @@ import ro.pippo.core.Request;
 import ro.pippo.core.RequestResponse;
 import ro.pippo.core.RequestResponseFactory;
 import ro.pippo.core.Response;
+import ro.pippo.core.util.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -53,7 +54,9 @@ public class GZipRequestResponseFactory extends RequestResponseFactory {
     protected boolean acceptsGZipEncoding(HttpServletRequest httpServletRequest) {
         String acceptEncoding = httpServletRequest.getHeader("accept-encoding");
 
-        return acceptEncoding != null && acceptEncoding.contains("gzip");
+        return !StringUtils.isNullOrEmpty(acceptEncoding) && (
+            acceptEncoding.contains("gzip")  || acceptEncoding.contains("*")
+        );
     }
 
 }

--- a/pippo-core/src/test/java/ro/pippo/core/gzip/GZipRequestResponseFactoryTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/gzip/GZipRequestResponseFactoryTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core.gzip;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import ro.pippo.core.Application;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GZipRequestResponseFactoryTest {
+
+    @Test
+    public void testAcceptGzipEncoding() {
+        GZipRequestResponseFactory requestResponseFactory = new GZipRequestResponseFactory(new Application());
+        HttpServletRequest httpServletRequest = Mockito.mock(HttpServletRequest.class);
+
+        // Accept-Encoding not specified
+        Mockito.doReturn(null).when(httpServletRequest).getHeader("accept-encoding");
+        assertFalse(requestResponseFactory.acceptsGZipEncoding(httpServletRequest));
+
+        // Accept-Encoding specified
+        Mockito.doReturn("gzip,deflate,identity").when(httpServletRequest).getHeader("accept-encoding");
+        assertTrue(requestResponseFactory.acceptsGZipEncoding(httpServletRequest));
+
+        // Explicit Accept-Encoding:*
+        Mockito.doReturn("*").when(httpServletRequest).getHeader("accept-encoding");
+        assertTrue(requestResponseFactory.acceptsGZipEncoding(httpServletRequest));
+
+        // No Gzip
+        Mockito.doReturn("deflate,identity").when(httpServletRequest).getHeader("accept-encoding");
+        assertFalse(requestResponseFactory.acceptsGZipEncoding(httpServletRequest));
+    }
+}


### PR DESCRIPTION
* When explicit * is specified in Accept-Encoding then send
  gzip response
Fixes #473

@decebals This PR doesn't include `qvalue` changes 