### PR TITLE
Issue #480 - Use WebSockets.sendClose to send close code/reason

### DIFF
--- a/pippo-server-parent/pippo-undertow/src/main/java/ro/pippo/undertow/websocket/UndertowWebSocketConnection.java
+++ b/pippo-server-parent/pippo-undertow/src/main/java/ro/pippo/undertow/websocket/UndertowWebSocketConnection.java
@@ -45,13 +45,7 @@ public class UndertowWebSocketConnection implements WebSocketConnection {
 
     @Override
     public void close(int code, String reason) {
-        channel.setCloseCode(code);
-        channel.setCloseReason(reason);
-        try {
-            channel.sendClose();
-        } catch (IOException e) {
-            throw new PippoRuntimeException(e);
-        }
+        WebSockets.sendClose(code, reason, channel, null);
     }
 
     @Override


### PR DESCRIPTION
fix for #480 