### PR TITLE
Issue #495 - do not call channel.resumeReceives() until handler.onOpen() called

### DIFF
--- a/pippo-server-parent/pippo-undertow/src/main/java/ro/pippo/undertow/websocket/UndertowWebSocketAdapter.java
+++ b/pippo-server-parent/pippo-undertow/src/main/java/ro/pippo/undertow/websocket/UndertowWebSocketAdapter.java
@@ -64,16 +64,16 @@ public class UndertowWebSocketAdapter extends AbstractReceiveListener implements
 
     @Override
     public void onConnect(WebSocketHttpExchange exchange, WebSocketChannel channel) {
-        channel.getReceiveSetter().set(this);
-        channel.resumeReceives();
-
         connection = new UndertowWebSocketConnection(exchange, channel);
         connections.add(connection);
-        channel.addCloseTask(ch -> connections.remove(connection));
 
         context = new WebSocketContext(connectionsReadOnly, connection, pathParameters);
 
         handler.onOpen(context);
+
+        channel.addCloseTask(ch -> connections.remove(connection));
+        channel.getReceiveSetter().set(this);
+        channel.resumeReceives();
     }
 
     @Override


### PR DESCRIPTION
Fix for #495 - move channel resume to the end of the `onConnect` method