### PR TITLE
Issue #497: adopt build for java 11

### DIFF
--- a/pippo-content-type-parent/pippo-csv/pom.xml
+++ b/pippo-content-type-parent/pippo-csv/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.6</version>
+            <version>1.18.6</version>
             <scope>test</scope>
         </dependency>
 

--- a/pippo-controller-parent/pippo-controller/src/main/java/ro/pippo/controller/ControllerHandler.java
+++ b/pippo-controller-parent/pippo-controller/src/main/java/ro/pippo/controller/ControllerHandler.java
@@ -462,7 +462,7 @@ public class ControllerHandler implements RouteHandler {
     /*
      * Cleans a complex content-type or accept header value by removing the
      * quality scores.
-     * <p/>
+     * <p>
      * <pre>
      * text/html,application/xhtml+xml,application/xml;q=0.9,image/webp
      * </pre>

--- a/pippo-controller-parent/pippo-controller/src/main/java/ro/pippo/controller/util/ClassUtils.java
+++ b/pippo-controller-parent/pippo-controller/src/main/java/ro/pippo/controller/util/ClassUtils.java
@@ -180,10 +180,11 @@ public class ClassUtils {
      * Class} object, including public, protected, default (package)
      * access, and private methods, <b>but excluding inherited methods</b>.
      *
-     * <p>This method differs from {@link Class#getDeclaredMethods()} since it
+     * <p>
+     * This method differs from {@link Class#getDeclaredMethods()} since it
      * does <b>not return bridge methods</b>, in other words, only the methods of
      * the class are returned. <b>If you just want the methods declared in
-     * {@code clazz} use this method!</b></p>
+     * {@code clazz} use this method!</b>
      *
      * @param clazz Class
      *

--- a/pippo-controller-parent/pippo-spring/src/main/java/ro/pippo/spring/SpringControllerFactory.java
+++ b/pippo-controller-parent/pippo-spring/src/main/java/ro/pippo/spring/SpringControllerFactory.java
@@ -68,7 +68,7 @@ public class SpringControllerFactory implements ControllerFactory {
     /**
      * Created a bean definition for a class.
      * Optionally configure all bean properties, like scope, prototype/singleton, etc using:
-     * <p/>
+     * <p>
      * <pre>
      * BeanDefinition definition = super.createBeanDefinition(beanClass);
      * definition.setScope(BeanDefinition.SCOPE_SINGLETON);

--- a/pippo-core/pom.xml
+++ b/pippo-core/pom.xml
@@ -22,6 +22,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Jaxb -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
+
         <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pippo-core/src/main/java/ro/pippo/core/AbstractWebServer.java
+++ b/pippo-core/src/main/java/ro/pippo/core/AbstractWebServer.java
@@ -107,7 +107,7 @@ public abstract class AbstractWebServer<T extends WebServerSettings> implements 
 
     /**
      * Override this method if you want to customize the {@link PippoFilter}.
-     * <p/>
+     * <p>
      * <pre>
      * protected PippoFilter createPippoFilter() {
      *     PippoFilter pippoFilter = super.createPippoFilter();

--- a/pippo-core/src/main/java/ro/pippo/core/ContentTypeEngines.java
+++ b/pippo-core/src/main/java/ro/pippo/core/ContentTypeEngines.java
@@ -108,7 +108,7 @@ public class ContentTypeEngines {
     /**
      * Returns the first matching content type engine for a content type suffix (json, xml, yaml), a
      * simple content type (application/json) or a complex accept header like:
-     * <p/>
+     * <p>
      * <pre>
      * text/html,application/xhtml+xml,application/xml;q=0.9,image/webp
      * </pre>
@@ -152,7 +152,7 @@ public class ContentTypeEngines {
     /**
      * Cleans a complex content-type or accept header value by removing the
      * quality scores.
-     * <p/>
+     * <p>
      * <pre>
      * text/html,application/xhtml+xml,application/xml;q=0.9,image/webp
      * </pre>

--- a/pippo-core/src/main/java/ro/pippo/core/DefaultUriMatcher.java
+++ b/pippo-core/src/main/java/ro/pippo/core/DefaultUriMatcher.java
@@ -181,7 +181,7 @@ public class DefaultUriMatcher implements UriMatcher {
 
     /**
      * Transforms an url pattern like "/{name}/id/*" into a regex like "/([^/]*)/id/*."
-     * <p/>
+     * <p>
      * Also handles regular expressions if defined inside routes:
      * For instance "/users/{username: [a-zA-Z][a-zA-Z_0-9]}" becomes
      * "/users/([a-zA-Z][a-zA-Z_0-9])"
@@ -242,9 +242,9 @@ public class DefaultUriMatcher implements UriMatcher {
 
     /**
      * Extracts the name of the parameters from a route
-     * <p/>
+     * <p>
      * /{my_id}/{my_name}
-     * <p/>
+     * <p>
      * would return a List with "my_id" and "my_name"
      *
      * @param uriPattern

--- a/pippo-core/src/main/java/ro/pippo/core/ErrorHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/ErrorHandler.java
@@ -23,7 +23,6 @@ import ro.pippo.core.route.RouteContext;
  * {@link ErrorHandler} can register custom {@link ExceptionHandler}s and will handle an exception
  * with a matching {@code ExceptionHandler}, if found. Otherwise {@code ErrorHandler} will fallback
  * to itself to handle the exception.
- * </p>
  *
  * @author Decebal Suiu
  */

--- a/pippo-core/src/main/java/ro/pippo/core/FileItem.java
+++ b/pippo-core/src/main/java/ro/pippo/core/FileItem.java
@@ -39,7 +39,7 @@ public class FileItem {
     /**
      * Gets the name of this part
      *
-     * @return The name of this part as a <tt>String</tt>
+     * @return The name of this part as a <code>String</code>
      */
     public String getName() {
         return  part.getName();
@@ -87,11 +87,11 @@ public class FileItem {
     }
 
     /**
-     * Gets the content of this part as an <tt>InputStream</tt>
+     * Gets the content of this part as an <code>InputStream</code>
      *
-     * @return The content of this file as an <tt>InputStream</tt>
+     * @return The content of this file as an <code>InputStream</code>
      * @throws IOException If an error occurs in retrieving the content
-     * as an <tt>InputStream</tt>
+     * as an <code>InputStream</code>
      */
     public InputStream getInputStream() throws IOException {
         return part.getInputStream();

--- a/pippo-core/src/main/java/ro/pippo/core/Languages.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Languages.java
@@ -27,9 +27,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * The Languages class manages the language and Locale of a Request & Response
+ * The Languages class manages the language and Locale of a Request &amp; Response
  * cycle. It can optionally persist a Language preference as a cookie.
- * <p/>
+ * <p>
  * This class is based on LangImpl.java from the Ninja Web Framework.
  *
  * @author James Moger
@@ -96,7 +96,6 @@ public class Languages {
      * For example, this application may have Portuguese (pt) as a registered
      * language but not Brazilian Portuguese (pt-BR). In this case, pt-BR would
      * be supported because of the pt registration.
-     * </p>
      *
      * @param language
      * @return true if the language is supported
@@ -115,7 +114,6 @@ public class Languages {
      * (messages_pt-BR.properties). In this case, pt-BR is not a registered
      * language, though it may be a supported language by the 'pt' language
      * component.
-     * </p>
      *
      * @param language
      * @return true if the language is registered
@@ -149,7 +147,6 @@ public class Languages {
      * <p>
      * If the language does not match a registered language or language
      * component an exception is thrown.
-     * </p>
      *
      * @param language
      * @param routeContext
@@ -166,7 +163,7 @@ public class Languages {
     }
 
     /**
-     * Returns the language for the request. This process considers Request &
+     * Returns the language for the request. This process considers Request &amp;
      * Response cookies, the Request ACCEPT_LANGUAGE header, and finally the
      * application default language.
      *
@@ -203,7 +200,7 @@ public class Languages {
     }
 
     /**
-     * Returns the Java Locale for the Request & Response cycle. If the language
+     * Returns the Java Locale for the Request &amp; Response cycle. If the language
      * specified in the Request/Response cycle can not be mapped to a Java
      * Locale, the default language Locale is returned.
      *

--- a/pippo-core/src/main/java/ro/pippo/core/Messages.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Messages.java
@@ -38,7 +38,7 @@ import java.util.TreeMap;
 /**
  * Loads and caches message resource files based on the registered languages in
  * application.properties.
- * <p/>
+ * <p>
  * This class is based on MessagesImpl.java from the Ninja Web Framework.
  *
  * @author James Moger
@@ -58,7 +58,7 @@ public class Messages {
 
     /**
      * Gets the requested localized message.
-     * <p/>
+     * <p>
      * <p>
      * The current Request and Response are used to help determine the messages
      * resource to use.
@@ -71,11 +71,9 @@ public class Messages {
      * <p>
      * The message can be formatted with optional arguments using the
      * {@link java.text.MessageFormat} syntax.
-     * </p>
      * <p>
      * If the key does not exist in the messages resource, then the key name is
      * returned.
-     * </p>
      *
      * @param key
      * @param routeContext
@@ -89,7 +87,7 @@ public class Messages {
 
     /**
      * Gets the requested localized message.
-     * <p/>
+     * <p>
      * <ol>
      * <li>Exact locale match, return the registered locale message
      * <li>Language match but not a locale match, return the registered language
@@ -99,11 +97,9 @@ public class Messages {
      * <p>
      * The message can be formatted with optional arguments using the
      * {@link java.text.MessageFormat} syntax.
-     * </p>
      * <p>
      * If the key does not exist in the messages resource, then the key name is
      * returned.
-     * </p>
      *
      * @param key
      * @param language
@@ -123,7 +119,7 @@ public class Messages {
 
     /**
      * Gets the requested localized message.
-     * <p/>
+     * <p>
      * <p>
      * The current Request and Response are used to help determine the messages
      * resource to use.
@@ -136,11 +132,9 @@ public class Messages {
      * <p>
      * The message can be formatted with optional arguments using the
      * {@link java.text.MessageFormat} syntax.
-     * </p>
      * <p>
      * If the key does not exist in the messages resource, then the key name is
      * returned.
-     * </p>
      *
      * @param key
      * @param defaultMessage
@@ -155,7 +149,7 @@ public class Messages {
 
     /**
      * Gets the requested localized message.
-     * <p/>
+     * <p>
      * <p>
      * The current Request and Response are used to help determine the messages
      * resource to use.
@@ -168,7 +162,6 @@ public class Messages {
      * <p>
      * The message can be formatted with optional arguments using the
      * {@link java.text.MessageFormat} syntax.
-     * </p>
      *
      * @param key
      * @param defaultMessage
@@ -196,7 +189,6 @@ public class Messages {
      * messages
      * <li>Return the default messages
      * </ol>
-     * </p>
      *
      * @param routeContext
      * @return all localized messages
@@ -356,7 +348,7 @@ public class Messages {
     /**
      * Retrieves the messages from an arbitrary one or two component language
      * String ("en-US", or "en" or "de"...).
-     * <p/>
+     * <p>
      *
      * @param language A one or two component language code such as "en", "en-US", or
      *                 "en-US,en;q=0.8,de;q=0.6".

--- a/pippo-core/src/main/java/ro/pippo/core/ParameterValue.java
+++ b/pippo-core/src/main/java/ro/pippo/core/ParameterValue.java
@@ -295,7 +295,7 @@ public class ParameterValue implements Serializable {
      *
      * @param classOfT
      * @param pattern  optional pattern for interpreting the underlying request
-     *                 string value. (used for date & time conversions)
+     *                 string value. (used for date &amp; time conversions)
      * @return a set of the values
      */
     public <T> Set<T> toSet(Class<T> classOfT, String pattern) {
@@ -393,7 +393,7 @@ public class ParameterValue implements Serializable {
      *
      * @param classOfT
      * @param pattern  optional pattern for interpreting the underlying request
-     *                 string value. (used for date & time conversions)
+     *                 string value. (used for date &amp; time conversions)
      * @return an object
      */
     @SuppressWarnings("unchecked")
@@ -437,7 +437,7 @@ public class ParameterValue implements Serializable {
      * @param collectionClass
      * @param classOfT
      * @param pattern  optional pattern for interpreting the underlying request
-     *                 string value. (used for date & time conversions)
+     *                 string value. (used for date &amp; time conversions)
      * @return a collection of the values
      */
     @SuppressWarnings("unchecked")

--- a/pippo-core/src/main/java/ro/pippo/core/Pippo.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Pippo.java
@@ -87,16 +87,12 @@ public class Pippo implements ResourceRouting, ReloadWatcher.Listener {
      * Entry point for a custom WebServer.
      * The idea is to create a custom WebServer if you want to override some aspects (method) of that server or
      * if you want free access to the servlet container (Jetty, Tomcat, ...).
-     *
      * <p>
-     * Show below the code for a <@code>JettyServer</@code> with persistent sessions.
-     * </p>
-     *
+     * Show below the code for a <code>JettyServer</code> with persistent sessions.
      * <pre>
-     * <@code>
      * public class MyJettyServer extends JettyServer {
      *
-     *     @Override
+     *     &#064;Override
      *     protected ServletContextHandler createPippoHandler() {
      *         ServletContextHandler handler = super.createPippoHandler();
      *
@@ -122,7 +118,6 @@ public class Pippo implements ResourceRouting, ReloadWatcher.Listener {
      *     }
      *
      * }
-     * </@code>
      * </pre>
      *
      * @param server

--- a/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
@@ -185,17 +185,17 @@ public class PippoFilter implements Filter {
      * Please note that you must subclass {@code PippoFilter.init(FilterConfig)} and set your filter path
      * before you call {@code super.init(filterConfig)}.
      * For example:
-     * {@code
+     * <pre>
      * class MyPippoFilter extends PippoFilter {
      *
-     *     @Override
+     *     &#064;Override
      *     public void init(FilterConfig filterConfig) throws ServletException {
      *         setFilterPath("/*");
      *         super.init(filterConfig);
      *     }
      *
      * }
-     * }
+     * </pre>
      *
      * @param urlPattern
      */

--- a/pippo-core/src/main/java/ro/pippo/core/PippoSettings.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoSettings.java
@@ -55,20 +55,15 @@ import java.util.concurrent.TimeUnit;
  * <li>from the application classpath (conf/application.properties)
  * <li>using the built-in Pippo properties
  * </ol>
- * </p>
  * <p>
  * A settings file located on the filesystem is automatically reloaded, if
  * modified, on the next setting lookup.
- * </p>
  * <p>
  * All settings support runtime-mode configuration allowing you to specify the
  * same setting with mode-dependent values.
- * </p>
  * <p>
  * Settings without a mode prefix are the shared for all modes unless explicitly
  * overridden by a mode-specific setting.
- * </p>
- * <p/>
  * <pre>
  * example.value = my example value
  * %prod.example.value = my production value
@@ -79,7 +74,6 @@ import java.util.concurrent.TimeUnit;
  * using the <i>include=</i> setting. The <i>include=</i> setting is a
  * comma-delimited field allowing importing settings from multiple sources.
  * Inclusions may be recursive.
- * </p>
  *
  * @author James Moger
  */
@@ -262,7 +256,6 @@ public class PippoSettings {
      * <p>
      * "Include" properties are the base properties which are overwritten by
      * the provided properties.
-     * </p>
      *
      * @param baseDir
      * @param properties
@@ -277,7 +270,6 @@ public class PippoSettings {
      * Recursively read "override" properties files.
      * <p>
      * "Override" properties overwrite the provided properties.
-     * </p>
      *
      * @param baseDir
      * @param properties
@@ -356,7 +348,6 @@ public class PippoSettings {
      * All values support the standard ${name} syntax but also support
      * the @{name} syntax to cope with build systems with aggressive
      * token filtering.
-     * </p>
      */
     protected void loadInterpolationValues() {
         // System properties may be accessed using ${name} or @{name}
@@ -767,7 +758,7 @@ public class PippoSettings {
 
     /**
      * Gets the duration setting and converts it to milliseconds.
-     * <p/>
+     * <p>
      * The setting must be use one of the following conventions:
      * <ul>
      * <li> n MILLISECONDS
@@ -786,7 +777,7 @@ public class PippoSettings {
 
     /**
      * Gets the duration setting and converts it to milliseconds.
-     * <p/>
+     * <p>
      * The setting must be use one of the following conventions:
      * <ul>
      * <li>n MILLISECONDS
@@ -809,7 +800,7 @@ public class PippoSettings {
 
     /**
      * Gets the duration setting and converts it to seconds.
-     * <p/>
+     * <p>
      * The setting must be use one of the following conventions:
      * <ul>
      * <li>n MILLISECONDS
@@ -828,7 +819,7 @@ public class PippoSettings {
 
     /**
      * Gets the duration setting and converts it to seconds.
-     * <p/>
+     * <p>
      * The setting must be use one of the following conventions:
      * <ul>
      * <li>n MILLISECONDS
@@ -851,7 +842,7 @@ public class PippoSettings {
 
     /**
      * Gets the duration setting and converts it to minutes.
-     * <p/>
+     * <p>
      * The setting must be use one of the following conventions:
      * <ul>
      * <li> n MILLISECONDS
@@ -870,7 +861,7 @@ public class PippoSettings {
 
     /**
      * Gets the duration setting and converts it to minutes.
-     * <p/>
+     * <p>
      * The setting must be use one of the following conventions:
      * <ul>
      * <li>n MILLISECONDS
@@ -893,7 +884,7 @@ public class PippoSettings {
 
     /**
      * Gets the duration setting and converts it to hours.
-     * <p/>
+     * <p>
      * The setting must be use one of the following conventions:
      * <ul>
      * <li> n MILLISECONDS
@@ -912,7 +903,7 @@ public class PippoSettings {
 
     /**
      * Gets the duration setting and converts it to hours.
-     * <p/>
+     * <p>
      * The setting must be use one of the following conventions:
      * <ul>
      * <li>n MILLISECONDS
@@ -935,7 +926,7 @@ public class PippoSettings {
 
     /**
      * Gets the duration setting and converts it to days.
-     * <p/>
+     * <p>
      * The setting must be use one of the following conventions:
      * <ul>
      * <li> n MILLISECONDS
@@ -954,7 +945,7 @@ public class PippoSettings {
 
     /**
      * Gets the duration setting and converts it to days.
-     * <p/>
+     * <p>
      * The setting must be use one of the following conventions:
      * <ul>
      * <li>n MILLISECONDS

--- a/pippo-core/src/main/java/ro/pippo/core/Request.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Request.java
@@ -104,7 +104,7 @@ public final class Request {
     }
 
     /**
-     * Returns all query&post parameters.
+     * Returns all query&amp;post parameters.
      */
     public Map<String, ParameterValue> getQueryParameters() {
         return parameters;
@@ -447,7 +447,7 @@ public final class Request {
     }
 
     /**
-     * Returns the url with the protocol, application path, & resource path. The
+     * Returns the url with the protocol, application path, &amp; resource path. The
      * query string is omitted.
      *
      * @return the url
@@ -457,7 +457,7 @@ public final class Request {
     }
 
     /**
-     * Returns the container uri with the application path & resource path. The
+     * Returns the container uri with the application path &amp; resource path. The
      * protocol and query string are omitted.
      *
      * @return the container uri

--- a/pippo-core/src/main/java/ro/pippo/core/RequestResponseFactory.java
+++ b/pippo-core/src/main/java/ro/pippo/core/RequestResponseFactory.java
@@ -19,7 +19,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * Helps in creating <code>Request<code/> and <code>Response<code/> objects.
+ * Helps in creating <code>Request</code> and <code>Response</code> objects.
  * Here you can wrap/customize HttpServletRequest or HttpServletResponse.
  *
  * @author Decebal Suiu

--- a/pippo-core/src/main/java/ro/pippo/core/Response.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Response.java
@@ -80,7 +80,6 @@ public final class Response {
      * for the current request/response cycle.
      * <p>
      * All bound objects are made available to the template engine during parsing.
-     * </p>
      *
      * @return the bound objects map
      */
@@ -410,7 +409,8 @@ public final class Response {
      * {@link ro.pippo.core.Response#redirectToContextPath(String)} method.
      * If you want an application-relative redirect, use the
      * {@link ro.pippo.core.Response#redirectToApplicationPath(String)} method.
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param location
      *            Where to redirect
@@ -430,7 +430,8 @@ public final class Response {
      * Redirects the browser to a path relative to the application context. For
      * example, redirectToContextPath("/contacts") might redirect the browser to
      * http://localhost/myContext/contacts
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param path
      */
@@ -447,7 +448,8 @@ public final class Response {
      * Redirects the browser to a path relative to the Pippo application root. For
      * example, redirectToApplicationPath("/contacts") might redirect the browser to
      * http://localhost/myContext/myApp/contacts
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param path
      */
@@ -462,7 +464,8 @@ public final class Response {
 
     /**
      * A permanent (3XX status code) redirect.
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param location
      * @param statusCode
@@ -489,7 +492,6 @@ public final class Response {
      * contain an entity corresponding to the requested resource. In a POST
      * request the response will contain an entity describing or containing the
      * result of the action.
-     * </p>
      *
      */
     public Response ok() {
@@ -502,7 +504,6 @@ public final class Response {
      * Set the response status to CREATED (201).
      * <p>
      * The request has been fulfilled and resulted in a new resource being created.
-     * </p>
      *
      */
     public Response created() {
@@ -517,7 +518,6 @@ public final class Response {
      * The request has been accepted for processing, but the processing has not
      * been completed. The request might or might not eventually be acted upon,
      * as it might be disallowed when processing actually takes place.
-     * </p>
      *
      */
     public Response accepted() {
@@ -531,7 +531,6 @@ public final class Response {
      * <p>
      * The server cannot or will not process the request due to something that
      * is perceived to be a client error.
-     * </p>
      *
      */
     public Response badRequest() {
@@ -547,7 +546,6 @@ public final class Response {
      * required and has failed or has not yet been provided. The response must
      * include a WWW-Authenticate header field containing a challenge applicable
      * to the requested resource.
-     * </p>
      */
     public Response unauthorized() {
         status(HttpConstants.StatusCode.UNAUTHORIZED);
@@ -561,7 +559,6 @@ public final class Response {
      * Reserved for future use. The original intention was that this code might
      * be used as part of some form of digital cash or micropayment scheme, but
      * that has not happened, and this code is not usually used.
-     * </p>
      */
     public Response paymentRequired() {
         status(HttpConstants.StatusCode.PAYMENT_REQUIRED);
@@ -575,7 +572,6 @@ public final class Response {
      * The request was a valid request, but the server is refusing to respond to
      * it. Unlike a 401 Unauthorized response, authenticating will make no
      * difference.
-     * </p>
      *
      */
     public Response forbidden() {
@@ -589,7 +585,6 @@ public final class Response {
      * <p>
      * The requested resource could not be found but may be available again in
      * the future. Subsequent requests by the client are permissible.
-     * </p>
      *
      */
     public Response notFound() {
@@ -604,7 +599,6 @@ public final class Response {
      * A request was made of a resource using a request method not supported
      * by that resource; for example, using GET on a form which requires data
      * to be presented via POST, or using PUT on a read-only resource.
-     * </p>
      *
      */
     public Response methodNotAllowed() {
@@ -618,7 +612,6 @@ public final class Response {
      * <p>
      * Indicates that the request could not be processed because of conflict in
      * the request, such as an edit conflict in the case of multiple updates.
-     * </p>
      *
      */
     public Response conflict() {
@@ -635,7 +628,6 @@ public final class Response {
      * intentionally removed and the resource should be purged. Upon receiving a
      * 410 status code, the client should not request the resource again in the
      * future.
-     * </p>
      *
      */
     public Response gone() {
@@ -649,7 +641,6 @@ public final class Response {
      * <p>
      * A generic error message, given when an unexpected condition was
      * encountered and no more specific message is suitable.
-     * </p>
      *
      */
     public Response internalError() {
@@ -664,7 +655,6 @@ public final class Response {
      * The server either does not recognize the request method, or it lacks the
      * ability to fulfil the request. Usually this implies future availability
      * (e.g., a new feature of a web-service API).
-     * </p>
      *
      */
     public Response notImplemented() {
@@ -678,7 +668,6 @@ public final class Response {
      * <p>
      * The server is currently unavailable (because it is overloaded or down
      * for maintenance). Generally, this is a temporary state.
-     * </p>
      */
     public Response overloaded() {
         status(HttpConstants.StatusCode.OVERLOADED);
@@ -691,7 +680,6 @@ public final class Response {
      * <p>
      * The server is currently unavailable (because it is overloaded or down
      * for maintenance). Generally, this is a temporary state.
-     * </p>
      */
     public Response serviceUnavailable() {
         status(HttpConstants.StatusCode.SERVICE_UNAVAILABLE);
@@ -748,7 +736,6 @@ public final class Response {
      * <p>
      * The Accept header is preferred for negotiation but the Content-Type
      * header may also be used if an agreeable engine can not be determined.
-     * </p>
      * <p>
      * If no Content-Type can not be negotiated then the response will not be
      * modified. This behavior allows specification of a default Content-Type
@@ -827,7 +814,8 @@ public final class Response {
 
     /**
      * Writes the string content directly to the response.
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param content
      */
@@ -840,7 +828,8 @@ public final class Response {
     /**
      * Replaces '{}' in the format string with the supplied arguments and
      * writes the string content directly to the response.
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param format
      * @param args
@@ -854,7 +843,8 @@ public final class Response {
     /**
      * Serializes the object as JSON using the registered <code>application/json</code>
      * ContentTypeEngine and writes it to the response.
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param object
      */
@@ -865,7 +855,8 @@ public final class Response {
     /**
      * Serializes the object as XML using the registered <code>application/xml</code>
      * ContentTypeEngine and writes it to the response.
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param object
      */
@@ -876,7 +867,8 @@ public final class Response {
     /**
      * Serializes the object as YAML using the registered <code>application/x-yaml</code>
      * ContentTypeEngine and writes it to the response.
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param object
      */
@@ -887,7 +879,8 @@ public final class Response {
     /**
      * Serializes the object as plain text using the registered <code>text/plain</code>
      * ContentTypeEngine and writes it to the response.
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param object
      */
@@ -898,7 +891,8 @@ public final class Response {
     /**
      * Serializes the object using the registered ContentTypeEngine matching
      * the pre-specified content-type.
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param object
      */
@@ -926,7 +920,8 @@ public final class Response {
 
     /**
      * Copies the input stream to the response output stream and closes the input stream upon completion.
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param input
      */
@@ -948,7 +943,8 @@ public final class Response {
 
     /**
      * Writes the specified file directly to the response.
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param file
      */
@@ -963,7 +959,8 @@ public final class Response {
 
     /**
      * Copies the input stream to the response output stream as a download and closes the input stream upon completion.
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param filename
      * @param input
@@ -1005,7 +1002,8 @@ public final class Response {
 
     /**
      * Renders a template and writes the output directly to the response.
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param templateName
      */
@@ -1015,7 +1013,8 @@ public final class Response {
 
     /**
      * Renders a template and writes the output directly to the response.
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param templateName
      * @param model

--- a/pippo-core/src/main/java/ro/pippo/core/TemplateHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/TemplateHandler.java
@@ -25,7 +25,6 @@ import java.util.Map;
  * <p>
  * This handler can be useful for designs which blend server-side page
  * generation with client-side applications.
- * </p>
  *
  * @author James Moger
  */

--- a/pippo-core/src/main/java/ro/pippo/core/WebServer.java
+++ b/pippo-core/src/main/java/ro/pippo/core/WebServer.java
@@ -27,14 +27,13 @@ public interface WebServer<T extends WebServerSettings> {
      * See also {@link WebServerInitializer}.
      *
      * <pre>
-     * {@code
+     * <code>
      * MyApplication application = (MyApplication) servletContext.getAttribute(PIPPO_APPLICATION);
-     * }
+     * </code>
      * </pre>
      *
      * A possible scenario: I want to add support for Jersey in my application.
      * <pre>
-     * {@code
      *
      * public class MyApplication extends Application {
      *
@@ -46,10 +45,10 @@ public interface WebServer<T extends WebServerSettings> {
      *
      * }
      *
-     * @MetaInfServices
+     * &#064;MetaInfServices
      * public class JerseyInitializer implements WebServerInitializer {
      *
-     *     @Override
+     *     &#064;Override
      *     public void init(ServletContext servletContext) {
      *         // get the resourceConfig via application
      *         MyApplication application = (MyApplication) servletContext.getAttribute(PIPPO_APPLICATION);
@@ -61,7 +60,7 @@ public interface WebServer<T extends WebServerSettings> {
      *         jerseyServlet.addMapping("/api/*");
      *     }
      *
-     *     @Override
+     *     &#064;Override
      *     public void destroy(ServletContext servletContext) {
      *         // do nothing for now
      *     }

--- a/pippo-core/src/main/java/ro/pippo/core/route/CorsHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/CorsHandler.java
@@ -27,11 +27,8 @@ import ro.pippo.core.util.StringUtils;
  * The Cross-Origin Resource Sharing standard works by adding new HTTP headers
  * that allow servers to describe the set of origins that are permitted to read
  * that information using a web browser.
- * </p>
- *
  * <p>
  * For more details see: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
- * </p>
  */
 public class CorsHandler implements RouteHandler<RouteContext> {
 

--- a/pippo-core/src/main/java/ro/pippo/core/route/ResourceRouting.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/ResourceRouting.java
@@ -18,7 +18,7 @@ package ro.pippo.core.route;
 import java.io.File;
 
 /**
- * An extension of <@link>Routing</@link> that add support for <@code>Resource</@code>.
+ * An extension of {@link Routing} that add support for <code>Resource</code>.
  *
  * @author Decebal Suiu
  */

--- a/pippo-core/src/main/java/ro/pippo/core/route/RouteContext.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/RouteContext.java
@@ -92,7 +92,8 @@ public interface RouteContext {
 
     /**
      * Renders a template and writes the output directly to the response.
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param templateName
      */
@@ -100,7 +101,8 @@ public interface RouteContext {
 
     /**
      * Renders a template and writes the output directly to the response.
-     * <p>This method commits the response.</p>
+     * <p>
+     * This method commits the response.
      *
      * @param templateName
      * @param model

--- a/pippo-core/src/main/java/ro/pippo/core/route/Router.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/Router.java
@@ -99,14 +99,14 @@ public interface Router {
      * For example:
      * <pre>
      * // add a route
-     * GET("/user", routeContext -> {...});
+     * GET("/user", routeContext -&gt; {...});
      *
      * // get an uri string for the above route
-     * Map<String, Object> parameters = new HashMap<>();
+     * Map&lt;String, Object&gt; parameters = new HashMap&lt;&gt;();
      * parameters.put("admin", true);
      * parameters.put("company", "Home Office")
      * String uri = uriFor("/user", parameters);
-     * // the result is "/user?admin=true&company=Home+Office"
+     * // the result is "/user?admin=true&amp;company=Home+Office"
      * </pre>
      * The parameters values are automatically encoded by this method.
      *

--- a/pippo-core/src/main/java/ro/pippo/core/route/TrailingSlashHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/TrailingSlashHandler.java
@@ -32,7 +32,6 @@ import ro.pippo.core.util.StringUtils;
  * Note:
  * For GET requests a temporary redirect (302) is fine, but for other request methods like POST or PUT
  * the browser will send the second request with the GET method.
- * </p>
  *
  * @author Decebal Suiu
  */

--- a/pippo-core/src/main/java/ro/pippo/core/route/WebjarsResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/WebjarsResourceHandler.java
@@ -109,7 +109,7 @@ public class WebjarsResourceHandler extends ClasspathResourceHandler {
      * for all Webjars on the classpath.
      * <p>
      * This allows specifications of a path like "jquery/jquery.min.js" which will be substituted
-     * at runtime as "jquery/1.11.1/jquery.min.js".</p>
+     * at runtime as "jquery/1.11.1/jquery.min.js".
      *
      * @return a map of path pathAliases
      */

--- a/pippo-core/src/main/java/ro/pippo/core/util/DateUtils.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/DateUtils.java
@@ -37,7 +37,7 @@ public class DateUtils {
 
     /**
      * Can be used to format a date into http header compatible strings.
-     * <p/>
+     * <p>
      * It can be used to generate something like: Date: Wed, 05 Sep 2012
      * 09:16:19 GMT Expires: Thu, 01 Jan 1970 00:00:00 GMT
      *
@@ -52,7 +52,7 @@ public class DateUtils {
     /**
      * Can be used to format a unix timestamp into http header compatible
      * strings.
-     * <p/>
+     * <p>
      * It can be used to generate something like: Date: Wed, 05 Sep 2012
      * 09:16:19 GMT Expires: Thu, 01 Jan 1970 00:00:00 GMT
      *
@@ -67,7 +67,7 @@ public class DateUtils {
     /**
      * Can be used to parse http times. For instance something like a http
      * header Date: Tue, 26 Mar 2013 13:47:13 GMT
-     * <p/>
+     * <p>
      * INFO: consider the JodaTime based
      * DateUtil.parseHttpDateFormatToDateTime(...) version
      *

--- a/pippo-core/src/main/java/ro/pippo/core/util/MimeTypes.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/MimeTypes.java
@@ -28,7 +28,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * MimeTypes utils adapted from Play 1.2.4 & Ninja Web Framework
+ * MimeTypes utils adapted from Play 1.2.4 &amp; Ninja Web Framework
  */
 public class MimeTypes {
 
@@ -58,7 +58,7 @@ public class MimeTypes {
     }
 
     /**
-     * Returns the mimetype from a file name.<br/>
+     * Returns the mimetype from a file name.<br>
      *
      * @param filename        the file name
      * @param defaultMimeType the default mime type to return when no matching mimetype is
@@ -85,7 +85,7 @@ public class MimeTypes {
 
     /**
      * Returns the content-type from a file name. If none is found returning
-     * application/octet-stream<br/>
+     * application/octet-stream<br>
      * For a text-based content-type, also return the encoding suffix eg.
      * <em>"text/plain; charset=utf-8"</em>
      *
@@ -97,7 +97,7 @@ public class MimeTypes {
     }
 
     /**
-     * Returns the content-type from a file name.<br/>
+     * Returns the content-type from a file name.<br>
      * For a text-based content-type, also return the encoding suffix eg.
      * <em>"text/plain; charset=utf-8"</em>
      *

--- a/pippo-core/src/main/java/ro/pippo/core/util/PathRegexBuilder.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/PathRegexBuilder.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 /**
  * An utility class that help you to create complex regex paths using only includes and excludes.
- * <p/>
  * <pre>
  * private String securePaths() {
  *     return new PathRegexBuilder()

--- a/pippo-core/src/main/java/ro/pippo/core/util/StringUtils.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/StringUtils.java
@@ -25,7 +25,8 @@ import java.util.regex.PatternSyntaxException;
  */
 public class StringUtils {
 
-    private StringUtils() {}
+    private StringUtils() {
+    }
 
     public static boolean isNullOrEmpty(String s) {
         return s == null || s.trim().isEmpty();
@@ -53,13 +54,14 @@ public class StringUtils {
     }
 
     /**
-     * <p>Removes a substring only if it is at the start of a source string,
-     * otherwise returns the source string.</p>
-     * <p/>
-     * <p>A {@code null} source string will return {@code null}.
+     * <p>
+     * Removes a substring only if it is at the start of a source string,
+     * otherwise returns the source string.
+     * <p>
+     * A {@code null} source string will return {@code null}.
      * An empty ("") source string will return the empty string.
-     * A {@code null} search string will return the source string.</p>
-     * <p/>
+     * A {@code null} search string will return the source string.
+     * <p>
      * <pre>
      * StringUtils.removeStart(null, *)      = null
      * StringUtils.removeStart("", *)        = ""
@@ -86,13 +88,12 @@ public class StringUtils {
     }
 
     /**
-     * <p>Removes a substring only if it is at the end of a source string,
-     * otherwise returns the source string.</p>
-     * <p/>
-     * <p>A {@code null} source string will return {@code null}.
+     * Removes a substring only if it is at the end of a source string,
+     * otherwise returns the source string.
+     * <p>
+     * A {@code null} source string will return {@code null}.
      * An empty ("") source string will return the empty string.
-     * A {@code null} search string will return the source string.</p>
-     * <p/>
+     * A {@code null} search string will return the source string.
      * <pre>
      * StringUtils.removeEnd(null, *)      = null
      * StringUtils.removeEnd("", *)        = ""
@@ -121,13 +122,13 @@ public class StringUtils {
     }
 
     /**
-     * <p>Adds a substring only if the source string does not already start with the substring,
-     * otherwise returns the source string.</p>
-     * <p/>
-     * <p>A {@code null} source string will return {@code null}.
+     * <p>
+     * Adds a substring only if the source string does not already start with the substring,
+     * otherwise returns the source string.
+     * <p>
+     * A {@code null} source string will return {@code null}.
      * An empty ("") source string will return the empty string.
-     * A {@code null} search string will return the source string.</p>
-     * <p/>
+     * A {@code null} search string will return the source string.
      * <pre>
      * StringUtils.addStart(null, *)      = *
      * StringUtils.addStart("", *)        = *
@@ -157,13 +158,14 @@ public class StringUtils {
     }
 
     /**
-     * <p>Adds a substring only if the source string does not already end with the substring,
-     * otherwise returns the source string.</p>
-     * <p/>
-     * <p>A {@code null} source string will return {@code null}.
+     * <p>
+     * Adds a substring only if the source string does not already end with the substring,
+     * otherwise returns the source string.
+     * <p>
+     * A {@code null} source string will return {@code null}.
      * An empty ("") source string will return the empty string.
-     * A {@code null} search string will return the source string.</p>
-     * <p/>
+     * A {@code null} search string will return the source string.
+     * <p>
      * <pre>
      * StringUtils.addEnd(null, *)      = *
      * StringUtils.addEnd("", *)        = *

--- a/pippo-core/src/test/java/ro/pippo/core/AbstractTemplateEngineTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/AbstractTemplateEngineTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import ro.pippo.core.route.RouteContext;
 import ro.pippo.core.route.Router;
 
@@ -31,7 +31,7 @@ import java.util.Map;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -179,7 +179,7 @@ public class AbstractTemplateEngineTest {
     @Test
     public void shouldReturnDefaultTemplateFileExtensionIfNotConfiguredInSettings() {
         when(mockPippoSettings.getString(anyString(), anyString()))
-            .then(args -> args.getArgumentAt(1, String.class));
+            .then(args -> args.getArgument(1));
 
         templateEngine.init(mockApplication);
 
@@ -208,7 +208,7 @@ public class AbstractTemplateEngineTest {
     @Test
     public void shouldReturnDefaultTemplatePathPrefixIfNotConfiguredInSettings() {
         when(mockPippoSettings.getString(anyString(), anyString()))
-            .then(args -> args.getArgumentAt(1, String.class));
+            .then(args -> args.getArgument(1));
 
         templateEngine.init(mockApplication);
 

--- a/pippo-core/src/test/java/ro/pippo/core/DefaultErrorHandlerTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/DefaultErrorHandlerTest.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import ro.pippo.core.route.RouteContext;
 
 /**

--- a/pippo-metrics-parent/pippo-metrics/src/main/java/ro/pippo/metrics/Counted.java
+++ b/pippo-metrics-parent/pippo-metrics/src/main/java/ro/pippo/metrics/Counted.java
@@ -37,14 +37,14 @@ public @interface Counted {
 
     /**
      * Determines the behavior of the counter.
-     * <p/>
+     * <p>
      * if false (default), the counter will continuously increment and will
      * indicate the number of times this method has been executed.
-     * <p/>
+     * <p>
      * if true, the counter will be incremented before the method is executed
      * and will be decremented when method execution has completed - regardless
      * of thrown exceptions.
-     * <p/>
+     * <p>
      * This is useful for determining the realtime execution status of a method.
      */
     boolean active() default false;

--- a/pippo-server-parent/pippo-tjws/src/main/java/ro/pippo/tjws/TjwsServer.java
+++ b/pippo-server-parent/pippo-tjws/src/main/java/ro/pippo/tjws/TjwsServer.java
@@ -36,12 +36,12 @@ import java.util.Properties;
 
 /**
  * RESTEasy TJWS is a 100KB Servlet 2.5 container.
- * <p/>
+ * <p>
  * Not all Pippo features are available in Servlet 2.5, specifically
  * file uploading and servlet filters.
- * <p/>
+ * <p>
  * TjwsServer uses PippoServlet.
- *
+ * <p>
  * TjwsServer doesn't support {@link ServletContextListener}.
  *
  * @author James Moger

--- a/pippo-session-parent/pippo-session-ehcache3/pom.xml
+++ b/pippo-session-parent/pippo-session-ehcache3/pom.xml
@@ -32,6 +32,21 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>${xml.bind.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>${xml.bind.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <version>1.7</version>

--- a/pippo-session-parent/pippo-session-mongodb/src/main/java/ro/pippo/session/mongodb/MongoDBFactory.java
+++ b/pippo-session-parent/pippo-session-mongodb/src/main/java/ro/pippo/session/mongodb/MongoDBFactory.java
@@ -50,7 +50,7 @@ public class MongoDBFactory {
      * @param hosts list of hosts of the form
      * "mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]"
      * @return MongoDB client
-     * @see https://docs.mongodb.com/manual/reference/connection-string/
+     * @see <a href="https://docs.mongodb.com/manual/reference/connection-string/">Mongo docs</a>
      */
     public static MongoClient create(String hosts) {
         MongoClientURI connectionString = new MongoClientURI(hosts);

--- a/pippo-session-parent/pippo-session-mongodb/src/main/java/ro/pippo/session/mongodb/MongoDBSessionDataStorage.java
+++ b/pippo-session-parent/pippo-session-mongodb/src/main/java/ro/pippo/session/mongodb/MongoDBSessionDataStorage.java
@@ -102,7 +102,7 @@ public class MongoDBSessionDataStorage implements SessionDataStorage {
      * Create TTL index
      *
      * @param idleTime idle time in seconds
-     * @see https://docs.mongodb.com/manual/core/index-ttl/
+     * @see <a href="https://docs.mongodb.com/manual/core/index-ttl/">Mongo docs</a>
      */
     private void createIndex(long idleTime) {
         try {

--- a/pippo-template-parent/pippo-trimou/src/main/java/ro/pippo/trimou/AngularJsHelper.java
+++ b/pippo-template-parent/pippo-trimou/src/main/java/ro/pippo/trimou/AngularJsHelper.java
@@ -24,10 +24,9 @@ import com.google.common.base.Joiner;
  * <p>
  * AngularJS helper allows you to use the double-brace markup for both Trimou
  * and AngularJS.
- * </p>
- * <code>
+ * <pre>
  * {{ng foo bar | filter | whatever}}
- * </code>
+ * </pre>
  *
  * @author James Moger
  *

--- a/pippo-template-parent/pippo-trimou/src/main/java/ro/pippo/trimou/I18nHelper.java
+++ b/pippo-template-parent/pippo-trimou/src/main/java/ro/pippo/trimou/I18nHelper.java
@@ -27,16 +27,14 @@ import ro.pippo.core.Messages;
 /**
  * <p>
  * Using the i18n helper:
- * </p>
- * <code>
+ * <pre>
  * {{i18n "my.key"}}
- * </code>
+ * </pre>
  * <p>
  * Passing arguments to the MessageFormat string formatter:
- * </p>
- * <code>
+ * <pre>
  * {{i18n "hello.world" "Frank"}}
- * </code>
+ * </pre>
  *
  * @author James Moger
  */

--- a/pippo-template-parent/pippo-velocity/src/main/java/ro/pippo/velocity/PrefixedClasspathResourceLoader.java
+++ b/pippo-template-parent/pippo-velocity/src/main/java/ro/pippo/velocity/PrefixedClasspathResourceLoader.java
@@ -21,7 +21,7 @@ import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
 import java.io.InputStream;
 
 /**
- * @see http://stackoverflow.com/a/9693749/390044
+ * @see <a href="http://stackoverflow.com/a/9693749/390044">Stack Overflow</a>
  *
  * @author Decebal Suiu
  */

--- a/pippo-test/src/main/java/ro/pippo/test/PippoTest.java
+++ b/pippo-test/src/main/java/ro/pippo/test/PippoTest.java
@@ -23,15 +23,14 @@ import com.jayway.restassured.RestAssured;
  * <p>
  * PippoTest will start your Pippo application on a dynamically assigned port
  * in TEST mode for execution of your unit tests.
- * </p>
  * <pre>
  * // one Pippo instance for EACH test
- * @Rule
+ * &#064;Rule
  * public PippoRule pippoRule = new PippoRule(new PippoApplication());
  *
  * // or
  * // one Pippo instance for ALL tests
- * @ClassRule
+ * &#064;ClassRule
  * public static PippoRule pippoRule = new PippoRule(new PippoApplication());
  * </pre>
  *

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <jaxb.version>2.3.1</jaxb.version>
+        <xml.bind.version>2.3.0.1</xml.bind.version>
 
         <servlet.version>3.0.1</servlet.version>
         <slf4j.version>1.7.7</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,14 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
+        <jaxb.version>2.3.1</jaxb.version>
+
         <servlet.version>3.0.1</servlet.version>
         <slf4j.version>1.7.7</slf4j.version>
         <metrics.version>4.0.2</metrics.version>
 
         <junit.version>4.12</junit.version>
-        <mockito.version>2.0.28-beta</mockito.version>
+        <mockito.version>2.24.0</mockito.version>
         <cobertura.version>2.7</cobertura.version>
         <coveralls.version>3.1.0</coveralls.version>
     </properties>
@@ -60,11 +62,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
-                    <optimize>true</optimize>
                     <encoding>UTF-8</encoding>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
@@ -75,7 +76,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -83,12 +84,21 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <!-- workaround for https://bugs.openjdk.java.net/browse/JDK-8212233 -->
+                    <javaApiLinks>
+                        <property>
+                            <name>foo</name>
+                            <value>bar</value>
+                        </property>
+                    </javaApiLinks>
+                </configuration>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -101,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5</version>
+                <version>2.5.3</version>
                 <configuration>
                     <goals>deploy</goals>
                     <autoVersionSubmodules>true</autoVersionSubmodules>


### PR DESCRIPTION
Various fixes to make maven build work on java 11 (see #497) :
- lombok version update. it is used in single file (test); can be removed completely from the project
- add explicit jaxb dependencies where required; see https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j
- fix javadoc issues (closing <p> tags, wrong `@see` syntax, html entities) 
- update mockito versions
- update maven plugin versions