### PR TITLE
Feature/java 11 build

### DIFF
--- a/pippo-content-type-parent/pippo-csv/pom.xml
+++ b/pippo-content-type-parent/pippo-csv/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.6</version>
+            <version>1.18.6</version>
             <scope>test</scope>
         </dependency>
 

--- a/pippo-core/pom.xml
+++ b/pippo-core/pom.xml
@@ -22,13 +22,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Jaxb -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>${jaxb.version}</version>
-        </dependency>
-
         <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -63,4 +56,20 @@
         </resources>
     </build>
 
+    <profiles>
+        <profile>
+            <id>jdk11-build</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <dependencies>
+                <!-- Jaxb -->
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                    <version>${jaxb.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/pippo-core/pom.xml
+++ b/pippo-core/pom.xml
@@ -22,6 +22,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Jaxb -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
+
         <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pippo-core/src/test/java/ro/pippo/core/AbstractTemplateEngineTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/AbstractTemplateEngineTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import ro.pippo.core.route.RouteContext;
 import ro.pippo.core.route.Router;
 
@@ -31,7 +31,7 @@ import java.util.Map;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -179,7 +179,7 @@ public class AbstractTemplateEngineTest {
     @Test
     public void shouldReturnDefaultTemplateFileExtensionIfNotConfiguredInSettings() {
         when(mockPippoSettings.getString(anyString(), anyString()))
-            .then(args -> args.getArgumentAt(1, String.class));
+            .then(args -> args.getArgument(1));
 
         templateEngine.init(mockApplication);
 
@@ -208,7 +208,7 @@ public class AbstractTemplateEngineTest {
     @Test
     public void shouldReturnDefaultTemplatePathPrefixIfNotConfiguredInSettings() {
         when(mockPippoSettings.getString(anyString(), anyString()))
-            .then(args -> args.getArgumentAt(1, String.class));
+            .then(args -> args.getArgument(1));
 
         templateEngine.init(mockApplication);
 

--- a/pippo-core/src/test/java/ro/pippo/core/DefaultErrorHandlerTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/DefaultErrorHandlerTest.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import ro.pippo.core.route.RouteContext;
 
 /**

--- a/pippo-session-parent/pippo-session-ehcache3/pom.xml
+++ b/pippo-session-parent/pippo-session-ehcache3/pom.xml
@@ -32,6 +32,21 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>${xml.bind.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>${xml.bind.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <version>1.7</version>

--- a/pippo-session-parent/pippo-session-ehcache3/pom.xml
+++ b/pippo-session-parent/pippo-session-ehcache3/pom.xml
@@ -32,21 +32,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>${jaxb.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-            <version>${xml.bind.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>${xml.bind.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <version>1.7</version>
@@ -68,5 +53,31 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>jdk11-build</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <dependencies>
+                <!-- Jaxb -->
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                    <version>${jaxb.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-core</artifactId>
+                    <version>${xml.bind.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
+                    <version>${xml.bind.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>

--- a/pippo-session-parent/pippo-session-mongodb/src/main/java/ro/pippo/session/mongodb/MongoDBFactory.java
+++ b/pippo-session-parent/pippo-session-mongodb/src/main/java/ro/pippo/session/mongodb/MongoDBFactory.java
@@ -50,7 +50,7 @@ public class MongoDBFactory {
      * @param hosts list of hosts of the form
      * "mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]"
      * @return MongoDB client
-     * @see https://docs.mongodb.com/manual/reference/connection-string/
+     * @see <a href="https://docs.mongodb.com/manual/reference/connection-string/">Mongo docs</a>
      */
     public static MongoClient create(String hosts) {
         MongoClientURI connectionString = new MongoClientURI(hosts);

--- a/pippo-session-parent/pippo-session-mongodb/src/main/java/ro/pippo/session/mongodb/MongoDBSessionDataStorage.java
+++ b/pippo-session-parent/pippo-session-mongodb/src/main/java/ro/pippo/session/mongodb/MongoDBSessionDataStorage.java
@@ -102,7 +102,7 @@ public class MongoDBSessionDataStorage implements SessionDataStorage {
      * Create TTL index
      *
      * @param idleTime idle time in seconds
-     * @see https://docs.mongodb.com/manual/core/index-ttl/
+     * @see <a href="https://docs.mongodb.com/manual/core/index-ttl/">Mongo docs</a>
      */
     private void createIndex(long idleTime) {
         try {

--- a/pippo-template-parent/pippo-velocity/src/main/java/ro/pippo/velocity/PrefixedClasspathResourceLoader.java
+++ b/pippo-template-parent/pippo-velocity/src/main/java/ro/pippo/velocity/PrefixedClasspathResourceLoader.java
@@ -21,7 +21,7 @@ import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
 import java.io.InputStream;
 
 /**
- * @see http://stackoverflow.com/a/9693749/390044
+ * @see <a href="http://stackoverflow.com/a/9693749/390044">Stack Overflow</a>
  *
  * @author Decebal Suiu
  */

--- a/pom.xml
+++ b/pom.xml
@@ -189,15 +189,6 @@
 
     <profiles>
         <profile>
-            <id>jdk8-build</id>
-            <activation>
-                <jdk>[1.8,)</jdk>
-            </activation>
-            <properties>
-                <additionalparam>-Xdoclint:none</additionalparam>
-            </properties>
-        </profile>
-        <profile>
             <id>travis</id>
             <activation>
                 <property>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
                             <value>bar</value>
                         </property>
                     </javaApiLinks>
+                    <doclint>none</doclint>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <jaxb.version>2.3.1</jaxb.version>
+        <xml.bind.version>2.3.0.1</xml.bind.version>
 
         <servlet.version>3.0.1</servlet.version>
         <slf4j.version>1.7.7</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,14 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
+        <jaxb.version>2.3.1</jaxb.version>
+
         <servlet.version>3.0.1</servlet.version>
         <slf4j.version>1.7.7</slf4j.version>
         <metrics.version>4.0.2</metrics.version>
 
         <junit.version>4.12</junit.version>
-        <mockito.version>2.0.28-beta</mockito.version>
+        <mockito.version>2.24.0</mockito.version>
         <cobertura.version>2.7</cobertura.version>
         <coveralls.version>3.1.0</coveralls.version>
     </properties>
@@ -60,11 +62,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
-                    <optimize>true</optimize>
                     <encoding>UTF-8</encoding>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
@@ -75,7 +76,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -83,12 +84,21 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <!-- workaround for https://bugs.openjdk.java.net/browse/JDK-8212233 -->
+                    <javaApiLinks>
+                        <property>
+                            <name>foo</name>
+                            <value>bar</value>
+                        </property>
+                    </javaApiLinks>
+                </configuration>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -101,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5</version>
+                <version>2.5.3</version>
                 <configuration>
                     <goals>deploy</goals>
                     <autoVersionSubmodules>true</autoVersionSubmodules>


### PR DESCRIPTION
Various fixes to make maven build work on java 11 (see #497, #498 ) :

* lombok version update. it is used in single file (test); can be removed completely from the project
* add explicit jaxb dependencies where required; see https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j
* update mockito versions
* update maven plugin versions