### PR TITLE
chore: upgrade fastjson to latest version

### DIFF
--- a/pippo-content-type-parent/pippo-fastjson/pom.xml
+++ b/pippo-content-type-parent/pippo-fastjson/pom.xml
@@ -15,7 +15,7 @@
     <description>Fastjson integration</description>
 
     <properties>
-        <fastjson.version>1.2.51</fastjson.version>
+        <fastjson.version>1.2.57</fastjson.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
* http://repo1.maven.org/maven2/com/alibaba/fastjson/1.2.57/
* This fixes fastjson test failures in different timezones
* This also has some performance improvements