### PR TITLE
ContentTypeEngine improvement

### DIFF
--- a/pippo-content-type-parent/pippo-gson/src/main/java/ro/pippo/gson/GsonEngine.java
+++ b/pippo-content-type-parent/pippo-gson/src/main/java/ro/pippo/gson/GsonEngine.java
@@ -45,8 +45,15 @@ import java.util.Locale;
 @MetaInfServices
 public class GsonEngine implements ContentTypeEngine {
 
+    private Gson gson;
+
     @Override
     public void init(Application application) {
+        this.gson = new GsonBuilder()
+            .registerTypeAdapter(Date.class, new ISO8601DateTimeTypeAdapter())
+            .registerTypeAdapter(Time.class, new ISO8601TimeTypeAdapter())
+            .registerTypeAdapter(java.sql.Date.class, new ISO8601DateTypeAdapter())
+            .create();
     }
 
     @Override
@@ -56,20 +63,12 @@ public class GsonEngine implements ContentTypeEngine {
 
     @Override
     public String toString(Object object) {
-        return gson().toJson(object);
+        return gson.toJson(object);
     }
 
     @Override
     public <T> T fromString(String content, Class<T> classOfT) {
-        return gson().fromJson(content, classOfT);
-    }
-
-    private Gson gson() {
-        return new GsonBuilder()
-            .registerTypeAdapter(Date.class, new ISO8601DateTimeTypeAdapter())
-            .registerTypeAdapter(Time.class, new ISO8601TimeTypeAdapter())
-            .registerTypeAdapter(java.sql.Date.class, new ISO8601DateTypeAdapter())
-            .create();
+        return gson.fromJson(content, classOfT);
     }
 
     public static class ISO8601DateTypeAdapter implements JsonSerializer<java.sql.Date>, JsonDeserializer<java.sql.Date> {

--- a/pippo-content-type-parent/pippo-jaxb/src/main/java/ro/pippo/jaxb/JaxbEngine.java
+++ b/pippo-content-type-parent/pippo-jaxb/src/main/java/ro/pippo/jaxb/JaxbEngine.java
@@ -44,6 +44,8 @@ public class JaxbEngine implements ContentTypeEngine {
     @Override
     public void init(Application application) {
         prettyPrint = application.getPippoSettings().isDev();
+        // JAXBContext is thread-safe - it is possible to cache by class
+        // https://javaee.github.io/jaxb-v2/doc/user-guide/ch03.html#other-miscellaneous-topics-performance-and-thread-safety
     }
 
     @Override

--- a/pippo-content-type-parent/pippo-snakeyaml/src/main/java/ro/pippo/snakeyaml/SnakeYamlEngine.java
+++ b/pippo-content-type-parent/pippo-snakeyaml/src/main/java/ro/pippo/snakeyaml/SnakeYamlEngine.java
@@ -31,6 +31,8 @@ public class SnakeYamlEngine implements ContentTypeEngine {
 
     @Override
     public void init(Application application) {
+        // Yaml - The implementation is not thread-safe. Different threads may not call the same instance. Threads must have separate Yaml instances.
+        // https://bitbucket.org/asomov/snakeyaml/wiki/Documentation#markdown-header-threading
     }
 
     @Override
@@ -45,7 +47,7 @@ public class SnakeYamlEngine implements ContentTypeEngine {
 
     @Override
     public <T> T fromString(String content, Class<T> classOfT) {
-        return (T) new Yaml().load(content);
+        return new Yaml().loadAs(content, classOfT);
     }
 
 }

--- a/pippo-content-type-parent/pippo-xstream/src/main/java/ro/pippo/xstream/XstreamEngine.java
+++ b/pippo-content-type-parent/pippo-xstream/src/main/java/ro/pippo/xstream/XstreamEngine.java
@@ -32,6 +32,9 @@ public class XstreamEngine implements ContentTypeEngine {
 
     @Override
     public void init(Application application) {
+        // XStream - it may be shared across multiple threads allowing objects to be serialized/deserialized concurrently,
+        // unless you enable the auto-detection to process annotations on-the-fly - which is our case with `autodetectAnnotations(true)`
+        // https://x-stream.github.io/faq.html#Scalability_Thread_safety
     }
 
     @Override


### PR DESCRIPTION
Solves #534 

Reuse de/serialization engines

To check
- [x] GsonEngine - changed
- [x] CsvEngine - there's nothing to change
- [x] FastjsonEngine - there's nothing to change
- [x] JacksonBaseEngine (abstract) - there's nothing to change
- [x] JacksonJsonEngine extends JacksonBaseEngine - there's nothing to change
- [x] JacksonXmlEngine extends JacksonBaseEngine - there's nothing to change
- [x] JacksonYamlEngine extends JacksonBaseEngine - there's nothing to change
- [x] JaxbEngine - not changed, but it is possible to cache only JAXBContext
- [x] SnakeYamlEngine - there's nothing to change, is not thread-safe
- [x] TextPlainEngine - there's nothing to change
- [x] XstreamEngine - there's nothing to change, is not thread-safe with autodetectAnnotations(true)
