### PR TITLE
Add possibility to disable suffix for Pebble loader

### DIFF
--- a/pippo-template-parent/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
+++ b/pippo-template-parent/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
@@ -82,7 +82,7 @@ public class PebbleTemplateEngine extends AbstractTemplateEngine {
             .extension(new AngularJSExtension())
             .extension(new WebjarsAtExtension(router))
             .extension(new PublicAtExtension(router))
-            .extension(new RouteExtension(application.getRouter()));
+            .extension(new RouteExtension(router));
 
         if (pippoSettings.isDev()) {
             // do not cache templates in dev mode

--- a/pippo-template-parent/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
+++ b/pippo-template-parent/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
@@ -67,7 +67,9 @@ public class PebbleTemplateEngine extends AbstractTemplateEngine {
 
         templateLoader.setCharset(PippoConstants.UTF8);
         templateLoader.setPrefix(getTemplatePathPrefix());
-        templateLoader.setSuffix("." + getFileExtension());
+        if (pippoSettings.getBoolean("pebble.suffix.enabled", true)) {
+            templateLoader.setSuffix("." + getFileExtension());
+        }
         loaders.add(templateLoader);
 
         PebbleEngine.Builder builder = new PebbleEngine.Builder()


### PR DESCRIPTION
### Problem

I cannot use the excellent [Pebble IntelliJ plugin](https://github.com/bjansen/pebble-intellij) to navigate on `include/extends`:

```
{% extends "base" %}
```

If I disabled the suffix (`.peb` that is added to the template name) I can navigate with CTRL + MOUSE CLICK to referenced template
 
```
{% extends "base.peb" %}
```

### Solution

The easy mode is to add a new `pebble.suffix.enabled` in `application.properties` as:
```
pebble.suffix.enabled = false
```

Of course is you disable the suffix (`.peb`) you render the template with:

```java
 Map<String, Object> model = new HashMap<>();
 model.put("users", ticketingService.getUsers());
 routeContext.render("users.peb", model);
```

instead 

```java
 Map<String, Object> model = new HashMap<>();
 model.put("users", ticketingService.getUsers());
 routeContext.render("users", model); // <<< WITHOUT `.peb` file extension
```