### PR TITLE
fix(sec): upgrade junit:junit to 4.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <slf4j.version>1.7.25</slf4j.version>
         <metrics.version>4.0.2</metrics.version>
 
-        <junit.version>4.13</junit.version>
+        <junit.version>4.13.1</junit.version>
         <mockito.version>2.24.0</mockito.version>
         <cobertura.version>2.7</cobertura.version>
         <coveralls.version>3.1.0</coveralls.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in junit:junit 4.13
- [CVE-2020-15250](https://www.oscs1024.com/hd/CVE-2020-15250)


### What did I do？
Upgrade junit:junit from 4.13 to 4.13.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS