### PR TITLE
Bumped pac4j version to 5.7.0 and mockito version to 4.9.0

### DIFF
--- a/pippo-security-parent/pippo-pac4j/pom.xml
+++ b/pippo-security-parent/pippo-pac4j/pom.xml
@@ -14,7 +14,8 @@
     <description>Pac4j integration</description>
 
     <properties>
-        <pac4j.version>2.2.0</pac4j.version>
+        <pac4j.version>5.7.0</pac4j.version>
+        <mockito.version>4.9.0</mockito.version>
     </properties>
 
     <dependencies>

--- a/pippo-security-parent/pippo-pac4j/src/main/java/ro/pippo/pac4j/Pac4jCallbackHandler.java
+++ b/pippo-security-parent/pippo-pac4j/src/main/java/ro/pippo/pac4j/Pac4jCallbackHandler.java
@@ -36,10 +36,10 @@ import java.util.Objects;
  */
 public class Pac4jCallbackHandler implements RouteHandler {
 
-    private CallbackLogic<Object, PippoWebContext> callbackLogic = new DefaultCallbackLogic<>();
+    private final String defaultClient;
+    private CallbackLogic callbackLogic = new DefaultCallbackLogic();
     private Config config;
     private String defaultUrl;
-    private Boolean multiProfile;
     private Boolean renewSession;
 
     public Pac4jCallbackHandler(Config config) {
@@ -47,18 +47,14 @@ public class Pac4jCallbackHandler implements RouteHandler {
     }
 
     public Pac4jCallbackHandler(Config config, String defaultUrl) {
-        this(config, defaultUrl, null);
+        this(config, defaultUrl, Boolean.FALSE, "");
     }
 
-    public Pac4jCallbackHandler(Config config, String defaultUrl, Boolean multiProfile) {
-        this(config, defaultUrl, multiProfile, null);
-    }
-
-    public Pac4jCallbackHandler(Config config, String defaultUrl, Boolean multiProfile, Boolean renewSession) {
+    public Pac4jCallbackHandler(Config config, String defaultUrl, Boolean renewSession, String defaultClient) {
         this.config = config;
         this.defaultUrl = defaultUrl;
-        this.multiProfile = multiProfile;
         this.renewSession = renewSession;
+        this.defaultClient = defaultClient;
     }
 
     @Override
@@ -69,14 +65,14 @@ public class Pac4jCallbackHandler implements RouteHandler {
 
         PippoWebContext webContext = new PippoWebContext(routeContext, config.getSessionStore());
 
-        callbackLogic.perform(webContext, config, config.getHttpActionAdapter(), defaultUrl, multiProfile, renewSession);
+        callbackLogic.perform(webContext, config.getSessionStore(), config, config.getHttpActionAdapter(), defaultUrl, renewSession, defaultClient);
     }
 
-    public CallbackLogic<Object, PippoWebContext> getCallbackLogic() {
+    public CallbackLogic getCallbackLogic() {
         return callbackLogic;
     }
 
-    public Pac4jCallbackHandler setCallbackLogic(CallbackLogic<Object, PippoWebContext> callbackLogic) {
+    public Pac4jCallbackHandler setCallbackLogic(CallbackLogic callbackLogic) {
         this.callbackLogic = callbackLogic;
 
         return this;
@@ -88,16 +84,6 @@ public class Pac4jCallbackHandler implements RouteHandler {
 
     public Pac4jCallbackHandler setDefaultUrl(String defaultUrl) {
         this.defaultUrl = defaultUrl;
-
-        return this;
-    }
-
-    public Boolean getMultiProfile() {
-        return multiProfile;
-    }
-
-    public Pac4jCallbackHandler setMultiProfile(Boolean multiProfile) {
-        this.multiProfile = multiProfile;
 
         return this;
     }

--- a/pippo-security-parent/pippo-pac4j/src/main/java/ro/pippo/pac4j/Pac4jLogoutHandler.java
+++ b/pippo-security-parent/pippo-pac4j/src/main/java/ro/pippo/pac4j/Pac4jLogoutHandler.java
@@ -38,7 +38,7 @@ import java.util.Objects;
  */
 public class Pac4jLogoutHandler implements RouteHandler {
 
-    private LogoutLogic<Object, PippoWebContext> logoutLogic = new DefaultLogoutLogic<>();
+    private LogoutLogic logoutLogic = new DefaultLogoutLogic();
     private Config config;
     private String defaultUrl;
     private String logoutUrlPattern;
@@ -68,14 +68,14 @@ public class Pac4jLogoutHandler implements RouteHandler {
 
         PippoWebContext webContext = new PippoWebContext(routeContext, config.getSessionStore());
 
-        logoutLogic.perform(webContext, config, config.getHttpActionAdapter(), defaultUrl, logoutUrlPattern, localLogout, destroySession, centralLogout);
+        logoutLogic.perform(webContext, config.getSessionStore(), config, config.getHttpActionAdapter(), defaultUrl, logoutUrlPattern, localLogout, destroySession, centralLogout);
     }
 
-    public LogoutLogic<Object, PippoWebContext> getLogoutLogic() {
+    public LogoutLogic getLogoutLogic() {
         return logoutLogic;
     }
 
-    public Pac4jLogoutHandler setLogoutLogic(LogoutLogic<Object, PippoWebContext> logoutLogic) {
+    public Pac4jLogoutHandler setLogoutLogic(LogoutLogic logoutLogic) {
         this.logoutLogic = logoutLogic;
 
         return this;

--- a/pippo-security-parent/pippo-pac4j/src/main/java/ro/pippo/pac4j/PippoNopHttpActionAdapter.java
+++ b/pippo-security-parent/pippo-pac4j/src/main/java/ro/pippo/pac4j/PippoNopHttpActionAdapter.java
@@ -15,7 +15,9 @@
  */
 package ro.pippo.pac4j;
 
-import org.pac4j.core.http.HttpActionAdapter;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.exception.http.HttpAction;
+import org.pac4j.core.http.adapter.HttpActionAdapter;
 
 /**
  * No-operation HTTP action adapter for the {@link PippoWebContext}.
@@ -28,7 +30,7 @@ import org.pac4j.core.http.HttpActionAdapter;
  *
  * @author Decebal Suiu
  */
-public class PippoNopHttpActionAdapter implements HttpActionAdapter<Void, PippoWebContext> {
+public class PippoNopHttpActionAdapter implements HttpActionAdapter {
 
     public static final PippoNopHttpActionAdapter INSTANCE = new PippoNopHttpActionAdapter();
 
@@ -37,8 +39,7 @@ public class PippoNopHttpActionAdapter implements HttpActionAdapter<Void, PippoW
     }
 
     @Override
-    public Void adapt(int code, PippoWebContext context) {
+    public Object adapt(HttpAction httpAction, WebContext webContext) {
         return null;
     }
-
 }

--- a/pippo-security-parent/pippo-pac4j/src/main/java/ro/pippo/pac4j/PippoWebContext.java
+++ b/pippo-security-parent/pippo-pac4j/src/main/java/ro/pippo/pac4j/PippoWebContext.java
@@ -26,6 +26,7 @@ import ro.pippo.core.route.RouteContext;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -38,31 +39,21 @@ import java.util.stream.Collectors;
 public class PippoWebContext implements WebContext {
 
     private final RouteContext routeContext;
-    private final SessionStore<PippoWebContext> sessionStore;
+    private final SessionStore sessionStore;
 
     public PippoWebContext(RouteContext routeContext) {
         this(routeContext, null);
     }
 
-    public PippoWebContext(RouteContext routeContext, SessionStore<PippoWebContext> sessionStore) {
+    public PippoWebContext(RouteContext routeContext, SessionStore sessionStore) {
         this.routeContext = routeContext;
         this.sessionStore = (sessionStore != null) ? sessionStore : new PippoSessionStore();
     }
 
     @Override
-    public SessionStore<PippoWebContext> getSessionStore() {
-        return sessionStore;
-    }
-
-    @Override
-    public void setSessionStore(SessionStore sessionStore) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public String getRequestParameter(String name) {
+    public Optional<String> getRequestParameter(String name) {
         ParameterValue parameter = getRequest().getParameter(name);
-        return parameter.isNull() ? null : parameter.toString();
+        return parameter.isNull() ? null : Optional.of(parameter.toString());
     }
 
     @Override
@@ -76,8 +67,8 @@ public class PippoWebContext implements WebContext {
     }
 
     @Override
-    public Object getRequestAttribute(String name) {
-        return getRequest().getHttpServletRequest().getAttribute(name);
+    public Optional getRequestAttribute(String name) {
+        return Optional.ofNullable(getRequest().getHttpServletRequest().getAttribute(name));
     }
 
     @Override
@@ -86,8 +77,8 @@ public class PippoWebContext implements WebContext {
     }
 
     @Override
-    public String getRequestHeader(String name) {
-        return getRequest().getHeader(name);
+    public Optional<String> getRequestHeader(String name) {
+        return Optional.ofNullable(getRequest().getHeader(name));
     }
 
     @Override
@@ -101,18 +92,13 @@ public class PippoWebContext implements WebContext {
     }
 
     @Override
-    public void writeResponseContent(String contentToWrite) {
-        getResponse().getWriter().write(contentToWrite);
-    }
-
-    @Override
-    public void setResponseStatus(int statusCode) {
-        getResponse().status(statusCode);
-    }
-
-    @Override
     public void setResponseHeader(String name, String value) {
         getResponse().header(name, value);
+    }
+
+    @Override
+    public Optional<String> getResponseHeader(String name) {
+        return Optional.of(getResponse().getHeader(name));
     }
 
     @Override
@@ -155,8 +141,6 @@ public class PippoWebContext implements WebContext {
             cookie.setHttpOnly(c.isHttpOnly());
             cookie.setDomain(c.getDomain());
             cookie.setMaxAge(c.getMaxAge());
-            cookie.setVersion(c.getVersion());
-
             return cookie;
         }).collect(Collectors.toList());
     }
@@ -193,4 +177,7 @@ public class PippoWebContext implements WebContext {
         return getRouteContext().getResponse();
     }
 
+    public SessionStore getSessionStore() {
+        return sessionStore;
+    }
 }

--- a/pippo-security-parent/pippo-pac4j/src/test/java/ro/pippo/pac4j/PippoSessionStoreTest.java
+++ b/pippo-security-parent/pippo-pac4j/src/test/java/ro/pippo/pac4j/PippoSessionStoreTest.java
@@ -18,9 +18,13 @@ package ro.pippo.pac4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import ro.pippo.core.Session;
 import ro.pippo.core.route.RouteContext;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpSessionContext;
+import java.util.*;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
@@ -50,7 +54,7 @@ public class PippoSessionStoreTest {
         PippoSessionStore sessionStore = new PippoSessionStore();
         Session session = sessionStore.getSession(mockPippoWebContext);
 
-        assertThat(session, is(mockSession));
+        assertThat(session, is(Optional.of(mockSession).get()));
 
         verify(mockRouteContext, times(1)).getSession();
         verify(mockPippoWebContext, times(1)).getRouteContext();
@@ -64,7 +68,7 @@ public class PippoSessionStoreTest {
         PippoSessionStore sessionStore = new PippoSessionStore();
         Object session = sessionStore.getTrackableSession(mockPippoWebContext);
 
-        assertThat(session, is(mockSession));
+        assertThat(session, is(Optional.of(mockSession)));
 
         verify(mockRouteContext, times(1)).getSession();
         verify(mockPippoWebContext, times(1)).getRouteContext();
@@ -81,7 +85,7 @@ public class PippoSessionStoreTest {
 
         PippoSessionStore sessionStore = new PippoSessionStore();
 
-        assertThat(sessionStore.get(mockPippoWebContext, expectedKey), is(expectedValue));
+        assertThat(sessionStore.get(mockPippoWebContext, expectedKey), is(Optional.of(expectedValue)));
 
         verify(mockSession, times(1)).get(expectedKey);
         verify(mockRouteContext, times(1)).getSession();
@@ -98,7 +102,7 @@ public class PippoSessionStoreTest {
 
         PippoSessionStore sessionStore = new PippoSessionStore();
 
-        assertThat(sessionStore.get(mockPippoWebContext, expectedKey), is(nullValue()));
+        assertThat(sessionStore.get(mockPippoWebContext, expectedKey), is(Optional.ofNullable(null)));
 
         verify(mockSession, times(1)).get(expectedKey);
         verify(mockRouteContext, times(1)).getSession();
@@ -130,7 +134,6 @@ public class PippoSessionStoreTest {
         when(mockPippoWebContext.getRouteContext()).thenReturn(mockRouteContext);
 
         PippoSessionStore sessionStore = new PippoSessionStore();
-
         sessionStore.set(mockPippoWebContext, expectedKey, null);
 
         verify(mockSession, times(1)).remove(expectedKey);
@@ -161,8 +164,7 @@ public class PippoSessionStoreTest {
         when(mockPippoWebContext.getRouteContext()).thenReturn(mockRouteContext);
 
         PippoSessionStore sessionStore = new PippoSessionStore();
-
-        assertThat(sessionStore.getOrCreateSessionId(mockPippoWebContext), is(expectedSessionId));
+        assertThat(sessionStore.getSessionId(mockPippoWebContext,false), is(Optional.of(expectedSessionId)));
 
         verify(mockSession, times(1)).getId();
         verify(mockRouteContext, times(1)).getSession();
@@ -183,6 +185,120 @@ public class PippoSessionStoreTest {
 
     @Test
     public void shouldBuildFromProvidedTrackableSession() {
+    }
+
+    private class HttpSession implements javax.servlet.http.HttpSession{
+
+        private final long creationTime;
+        private final String id;
+        private final long lastAccessTime;
+        private Map<String, Object> attributeMap = new HashMap<String, Object>();
+        private Map<String, Object> valueMap = new HashMap<String, Object>();
+
+        private HttpSession(){
+            this.creationTime = 0;
+            this.id = "SESSION-ID";
+            this.lastAccessTime = 0;
+        }
+        @Override
+        public long getCreationTime() {
+            return this.creationTime;
+        }
+
+        @Override
+        public String getId() {
+            return this.id;
+        }
+
+        @Override
+        public long getLastAccessedTime() {
+            return this.lastAccessTime;
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            throw new RuntimeException("NOT IMPLEMENTED");
+        }
+
+        @Override
+        public void setMaxInactiveInterval(int i) {
+
+        }
+
+        @Override
+        public int getMaxInactiveInterval() {
+            return 0;
+        }
+
+        /**
+         * @deprecated
+         */
+        @Override
+        public HttpSessionContext getSessionContext() {
+            throw new RuntimeException("NOT IMPLEMENTED");
+        }
+
+        @Override
+        public Object getAttribute(String key) {
+            return attributeMap.get(key);
+        }
+
+        @Override
+        public Object getValue(String key) {
+            return valueMap.get(key);
+        }
+
+        @Override
+        public Enumeration<String> getAttributeNames() {
+            return Collections.enumeration(attributeMap.keySet());
+        }
+
+        /**
+         * @deprecated
+         */
+        @Override
+        public String[] getValueNames() {
+            return new String[0];
+        }
+
+        @Override
+        public void setAttribute(String key, Object value) {
+            attributeMap.put(key,value);
+        }
+
+        /**
+         * @param s
+         * @param o
+         * @deprecated
+         */
+        @Override
+        public void putValue(String s, Object o) {
+            valueMap.put(s,o);
+        }
+
+        @Override
+        public void removeAttribute(String s) {
+            attributeMap.remove(s);
+        }
+
+        /**
+         * @param s
+         * @deprecated
+         */
+        @Override
+        public void removeValue(String s) {
+            valueMap.remove(s);
+        }
+
+        @Override
+        public void invalidate() {
+            throw new RuntimeException("NOT IMPLEMENTED");
+        }
+
+        @Override
+        public boolean isNew() {
+            return false;
+        }
     }
 
 }

--- a/pippo-security-parent/pippo-pac4j/src/test/java/ro/pippo/pac4j/PippoWebContextTest.java
+++ b/pippo-security-parent/pippo-pac4j/src/test/java/ro/pippo/pac4j/PippoWebContextTest.java
@@ -22,7 +22,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pac4j.core.context.Cookie;
 import org.pac4j.core.context.session.SessionStore;
 import ro.pippo.core.Application;
@@ -34,17 +34,13 @@ import ro.pippo.core.route.Router;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -91,18 +87,9 @@ public class PippoWebContextTest {
     public void shouldReturnPippoSessionStoreWhenAccessed() {
         PippoWebContext context = makePippoWebContext();
 
-        SessionStore<PippoWebContext> sessionStore = context.getSessionStore();
+        SessionStore sessionStore = context.getSessionStore();
         assertThat(sessionStore, instanceOf(PippoSessionStore.class));
-        assertThat(sessionStore.getTrackableSession(context), is(mockSession));
-    }
-
-    @Test
-    public void shouldThrowUnsupportedOperationExceptionIfSettingSessionStoreIsAttempted() {
-        PippoWebContext context = makePippoWebContext();
-
-        thrown.expect(UnsupportedOperationException.class);
-
-        context.setSessionStore(new PippoSessionStore());
+        assertThat(sessionStore.getTrackableSession(context).get(), is(mockSession));
     }
 
     @Test
@@ -117,7 +104,7 @@ public class PippoWebContextTest {
 
         PippoWebContext context = makePippoWebContext();
 
-        assertThat(context.getRequestParameter(expectedParameterName),
+        assertThat(context.getRequestParameter(expectedParameterName).get(),
             is(expectedParameterValue));
 
         verify(mockHttpRequest, times(1)).getParameterNames();
@@ -172,7 +159,7 @@ public class PippoWebContextTest {
 
         PippoWebContext context = makePippoWebContext();
 
-        assertThat(context.getRequestAttribute(expectedAttributeName), is(expectedAttributeValue));
+        assertThat(context.getRequestAttribute(expectedAttributeName).get(), is(expectedAttributeValue));
 
         verify(mockHttpRequest, times(1)).getAttribute(expectedAttributeName);
     }
@@ -185,7 +172,7 @@ public class PippoWebContextTest {
 
         PippoWebContext context = makePippoWebContext();
 
-        assertThat(context.getRequestAttribute(expectedAttributeName), is(nullValue()));
+        assertThat(context.getRequestAttribute(expectedAttributeName), is(Optional.ofNullable(null)));
 
         verify(mockHttpRequest, times(1)).getAttribute(expectedAttributeName);
     }
@@ -201,7 +188,7 @@ public class PippoWebContextTest {
 
         context.setRequestAttribute(expectedAttributeName, expectedAttributeValue);
 
-        assertThat(context.getRequestAttribute(expectedAttributeName), is(expectedAttributeValue));
+        assertThat(context.getRequestAttribute(expectedAttributeName).get(), is(expectedAttributeValue));
 
         verify(mockHttpRequest, times(1)).setAttribute(expectedAttributeName, expectedAttributeValue);
         verify(mockHttpRequest, times(1)).getAttribute(expectedAttributeName);


### PR DESCRIPTION
Bumped pac4j version to 5.7.0. The pac4j interfaces changed - dropped the use of generics and added support for java.util.Optional. 