### PR TITLE
Add resource route helper in router

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/Application.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Application.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Base class for all Pippo applications.
@@ -246,7 +247,8 @@ public class Application implements ResourceRouting {
     }
 
     public void setRouter(Router router, boolean preserveOldTransformers) {
-        if (preserveOldTransformers && (router != null)) {
+        Objects.requireNonNull(router);
+        if (preserveOldTransformers && (this.router != null)) {
             // preserve route transformers already registered
             List<RouteTransformer> transformers = this.router.getRouteTransformers();
             transformers.forEach(router::addRouteTransformer);

--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
@@ -43,7 +43,7 @@ import java.util.stream.StreamSupport;
  * @author Decebal Suiu
  * @author James Moger
  */
-public class DefaultRouter implements Router {
+public class DefaultRouter implements Router, ResourceRouting {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultRouter.class);
 


### PR DESCRIPTION
With this very simple modification I can extract the part with routes from `Application` in custom `Router`.
See below an example using Spring IoC:
```java
@Component
public class MyRouter extends DefaultRouter {

    @Autowired
    private List<RouteGroup> routeGroups;

    @Autowired
    private List<Route> routes;

    @PostConstruct
    public void addRoutes() {
        // ignore icon
        ignorePaths("/favicon.ico");

        // add routes for static content
        addPublicResourceRoute();
        addWebjarsResourceRoute();

        // filter that inject some info
        ANY("/.*", routeContext -> {
            routeContext.setLocal("version", version);
            routeContext.next();
        });

        // add registered routes
        routeGroups.forEach(this::addRouteGroup);
        routes.forEach(this::addRoute);

        GET("/threadDump", new ThreadDumpHandler());
        GET("/sysInfo", new SystemInfoHandler());
    }

}
``` 