### PR TITLE
Bump version of metainf-services to 1.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
             <dependency>
                 <groupId>org.kohsuke.metainf-services</groupId>
                 <artifactId>metainf-services</artifactId>
-                <version>1.7</version>
+                <version>1.9</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
1.7 is not compatible with Java 11 and causes warnings in tests:

	[WARNING] Supported source version 'RELEASE_8' from annotation processor 'org.kohsuke.metainf_services.AnnotationProcessorImpl' less than -source '11'